### PR TITLE
Add AppImage-aware self-update with download progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,6 @@ chmod +x GHelper-x86_64.AppImage
 ./GHelper-x86_64.AppImage
 ```
 
-> **Note:** The built-in auto-update mechanism does not work with AppImage. You will need to manually download and replace the AppImage file to update.
-
 ### `╠══[ BUILD FROM SOURCE ]══╣`
 
 ```bash


### PR DESCRIPTION
## Summary
- Detects AppImage mode via `$APPIMAGE` env var (set automatically by AppImage runtime)
- Downloads `GHelper-x86_64.AppImage` when running as AppImage, `ghelper` binary otherwise
- Replaces the `.AppImage` file on disk with backup (Linux allows replacing FUSE-mounted files)
- Adds download progress display (MB downloaded / total, percentage)
- Restart button execs the updated file — new AppImage gets fresh FUSE mount, old one cleans up on exit
- Removes README note that said AppImage auto-update doesn't work

## How it works
When running inside an AppImage, the runtime sets `$APPIMAGE=/path/to/GHelper-x86_64.AppImage`. The update code:
1. Checks GitHub releases API for latest version (same as before)
2. Picks the right asset based on mode (`.AppImage` vs bare `ghelper`)
3. Downloads to temp with progress reporting
4. Backs up current file to `.bak`
5. Atomically replaces the target file
6. Shows "Restart to apply" button → `Process.Start($APPIMAGE)` + `Environment.Exit(0)`