### PR TITLE
Fix fan curve control and add mid fan chart support

### DIFF
--- a/src/Helpers/Diagnostics.cs
+++ b/src/Helpers/Diagnostics.cs
@@ -218,7 +218,13 @@ public static class Diagnostics
                 continue;
 
             var perms = GetFilePermissions(path);
-            var value = Platform.Linux.SysfsHelper.ReadAttribute(path) ?? "(read failed)";
+            var value = Platform.Linux.SysfsHelper.ReadAttribute(path);
+
+            // kbd_rgb_mode and kbd_rgb_state are DEVICE_ATTR_WO in the kernel — read always fails
+            if (value == null && (path.EndsWith("kbd_rgb_mode") || path.EndsWith("kbd_rgb_state")))
+                value = "(write-only, present)";
+            else
+                value ??= "(read failed)";
 
             var shortPath = path
                 .Replace("/sys/class/power_supply/", "power_supply/")
@@ -350,6 +356,11 @@ public static class Diagnostics
             if (devices.Count == 0)
             {
                 sb.AppendLine("(none found)");
+
+                // Check if hid_asus module is loaded — needed for I2C-HID hidraw nodes
+                bool hidAsusLoaded = Directory.Exists("/sys/module/hid_asus");
+                if (!hidAsusLoaded)
+                    sb.AppendLine("  NOTE: hid_asus module not loaded (try: sudo modprobe hid_asus)");
             }
             else
             {
@@ -366,6 +377,7 @@ public static class Diagnostics
 
         sb.AppendLine($"AsusHid.IsAvailable: {USB.AsusHid.IsAvailable()}");
         sb.AppendLine($"AsusHid.UsingI2cHidraw: {USB.AsusHid.UsingI2cHidraw}");
+        sb.AppendLine($"Aura.IsAvailable: {USB.Aura.IsAvailable()}");
         sb.AppendLine();
     }
 

--- a/src/Platform/IAsusWmi.cs
+++ b/src/Platform/IAsusWmi.cs
@@ -37,6 +37,18 @@ public interface IAsusWmi : IDisposable
     /// <summary>Set fan curve (8 temp + 8 duty bytes).</summary>
     void SetFanCurve(int fanIndex, byte[] curve);
 
+    /// <summary>Disable custom fan curve for this fan (pwm_enable=2).
+    /// Returns to firmware thermal policy defaults for the current profile.</summary>
+    void DisableFanCurve(int fanIndex);
+
+    /// <summary>Reset fan curve to BIOS factory defaults (pwm_enable=3) and read back.
+    /// Returns the firmware default curve, or null if unsupported.</summary>
+    byte[]? ResetFanCurveToDefaults(int fanIndex);
+
+    /// <summary>Check if custom fan curve is active (pwm_enable==1). Returns false if
+    /// firmware is in control (pwm_enable==2 or 3) or if unsupported.</summary>
+    bool IsFanCurveEnabled(int fanIndex);
+
     // ── Battery ──
 
     /// <summary>Get charge limit (40-100).</summary>

--- a/src/Platform/Linux/LinuxAsusWmi.cs
+++ b/src/Platform/Linux/LinuxAsusWmi.cs
@@ -231,17 +231,40 @@ public class LinuxAsusWmi : IAsusWmi
 
         for (int i = 0; i < 8; i++)
         {
-            // Temperature in millidegrees → degrees
-            int tempMilli = SysfsHelper.ReadInt(
+            // Temperature: asus_custom_fan_curve sysfs uses raw degrees (NOT millidegrees).
+            // The kernel stores temps directly from the ACPI buffer: data->temps[i] = buf[i]
+            int temp = SysfsHelper.ReadInt(
                 Path.Combine(_asusFanCurveHwmonDir, $"pwm{pwmIndex}_auto_point{i + 1}_temp"), -1);
-            if (tempMilli < 0) return null;
-            curve[i] = (byte)(tempMilli / 1000);
+            if (temp < 0) return null;
+            curve[i] = (byte)temp;
 
             // PWM 0-255 → percentage 0-100
             int pwm = SysfsHelper.ReadInt(
                 Path.Combine(_asusFanCurveHwmonDir, $"pwm{pwmIndex}_auto_point{i + 1}_pwm"), -1);
             if (pwm < 0) return null;
             curve[8 + i] = (byte)(pwm * 100 / 255);
+        }
+
+        // The kernel's default fan curves for CPU/GPU often have all-zero temperatures
+        // but valid PWM duty cycles. This happens because the asus-wmi driver only
+        // populates temps when the user explicitly writes custom curves; the EC's
+        // built-in default temps are not exposed through sysfs.
+        // Synthesize a reasonable temperature ramp so the UI has usable data.
+        bool allTempsZero = true;
+        bool anyPwmNonZero = false;
+        for (int i = 0; i < 8; i++)
+        {
+            if (curve[i] > 0) allTempsZero = false;
+            if (curve[8 + i] > 0) anyPwmNonZero = true;
+        }
+
+        if (allTempsZero && anyPwmNonZero)
+        {
+            byte[] synthTemps = { 30, 40, 50, 60, 70, 80, 90, 100 };
+            for (int i = 0; i < 8; i++)
+                curve[i] = synthTemps[i];
+
+            Helpers.Logger.WriteLine($"Fan {fanIndex}: synthesized temp ramp for zero-temp kernel defaults");
         }
 
         return curve;
@@ -253,21 +276,58 @@ public class LinuxAsusWmi : IAsusWmi
 
         int pwmIndex = fanIndex + 1;
 
-        // First set pwm_enable to 2 (automatic/curve mode)
-        SysfsHelper.WriteInt(Path.Combine(_asusFanCurveHwmonDir, $"pwm{pwmIndex}_enable"), 2);
-
+        // Write all curve data points FIRST.
+        // Each sysfs write to auto_point files updates the in-kernel fan_curve_data struct
+        // and sets data->enabled = false (preventing premature writes to EC).
         for (int i = 0; i < 8; i++)
         {
-            // Degrees → millidegrees
+            // Temperature: asus_custom_fan_curve sysfs uses raw degrees (NOT millidegrees)
             SysfsHelper.WriteInt(
                 Path.Combine(_asusFanCurveHwmonDir, $"pwm{pwmIndex}_auto_point{i + 1}_temp"),
-                curve[i] * 1000);
+                curve[i]);
 
             // Percentage 0-100 → PWM 0-255
             SysfsHelper.WriteInt(
                 Path.Combine(_asusFanCurveHwmonDir, $"pwm{pwmIndex}_auto_point{i + 1}_pwm"),
                 curve[8 + i] * 255 / 100);
         }
+
+        // Enable custom curve: pwm_enable=1 sets data->enabled=true and calls
+        // fan_curve_write() which pushes the curve to the EC via WMI DEVS method.
+        SysfsHelper.WriteInt(Path.Combine(_asusFanCurveHwmonDir, $"pwm{pwmIndex}_enable"), 1);
+    }
+
+    public void DisableFanCurve(int fanIndex)
+    {
+        if (_asusFanCurveHwmonDir == null) return;
+        int pwmIndex = fanIndex + 1;
+
+        // pwm_enable=2 disables the custom curve for this fan, returning to
+        // the firmware's thermal policy defaults for the current profile.
+        SysfsHelper.WriteInt(Path.Combine(_asusFanCurveHwmonDir, $"pwm{pwmIndex}_enable"), 2);
+        Helpers.Logger.WriteLine($"Fan {fanIndex}: disabled custom curve (pwm_enable=2)");
+    }
+
+    public byte[]? ResetFanCurveToDefaults(int fanIndex)
+    {
+        if (_asusFanCurveHwmonDir == null) return null;
+        int pwmIndex = fanIndex + 1;
+
+        // pwm_enable=3 resets the fan curve to BIOS factory defaults for the
+        // currently active platform profile, then disables the custom curve.
+        SysfsHelper.WriteInt(Path.Combine(_asusFanCurveHwmonDir, $"pwm{pwmIndex}_enable"), 3);
+        Helpers.Logger.WriteLine($"Fan {fanIndex}: reset to factory defaults (pwm_enable=3)");
+
+        // Read back the firmware defaults so the UI can display them
+        return GetFanCurve(fanIndex);
+    }
+
+    public bool IsFanCurveEnabled(int fanIndex)
+    {
+        if (_asusFanCurveHwmonDir == null) return false;
+        int pwmIndex = fanIndex + 1;
+        return SysfsHelper.ReadInt(
+            Path.Combine(_asusFanCurveHwmonDir, $"pwm{pwmIndex}_enable"), 0) == 1;
     }
 
     // ── Battery ──

--- a/src/UI/Controls/FanCurveChart.cs
+++ b/src/UI/Controls/FanCurveChart.cs
@@ -31,6 +31,9 @@ public class FanCurveChart : Control
     public static readonly StyledProperty<string> FanLabelProperty =
         AvaloniaProperty.Register<FanCurveChart, string>(nameof(FanLabel), "CPU");
 
+    public static readonly StyledProperty<bool> DisabledProperty =
+        AvaloniaProperty.Register<FanCurveChart, bool>(nameof(Disabled), false);
+
     /// <summary>
     /// 16-byte fan curve: bytes 0-7 = temperatures (°C), bytes 8-15 = fan speeds (%)
     /// </summary>
@@ -50,6 +53,15 @@ public class FanCurveChart : Control
     {
         get => GetValue(FanLabelProperty);
         set => SetValue(FanLabelProperty, value);
+    }
+
+    /// <summary>
+    /// When true, draws a dark overlay with "Firmware control" text and suppresses drag interaction.
+    /// </summary>
+    public bool Disabled
+    {
+        get => GetValue(DisabledProperty);
+        set => SetValue(DisabledProperty, value);
     }
 
     // ── Constants ──
@@ -84,7 +96,7 @@ public class FanCurveChart : Control
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
         base.OnPropertyChanged(change);
-        if (change.Property == CurveDataProperty)
+        if (change.Property == CurveDataProperty || change.Property == DisabledProperty)
             InvalidateVisual();
     }
 
@@ -118,6 +130,22 @@ public class FanCurveChart : Control
             new Typeface("Segoe UI, Ubuntu, sans-serif", FontStyle.Normal, FontWeight.SemiBold),
             13, LabelBrush);
         context.DrawText(labelText, new Point(chartArea.Left + 5, 12));
+
+        // Disabled overlay — drawn when firmware is controlling fans (pwm_enable != 1)
+        if (Disabled)
+        {
+            var overlayBrush = new SolidColorBrush(Color.Parse("#CC1C1C1C")); // 80% opaque dark
+            context.FillRectangle(overlayBrush, bounds);
+
+            var overlayText = new FormattedText("Firmware control",
+                System.Globalization.CultureInfo.InvariantCulture,
+                FlowDirection.LeftToRight,
+                new Typeface("Segoe UI, Ubuntu, sans-serif", FontStyle.Normal, FontWeight.SemiBold),
+                16, new SolidColorBrush(Color.Parse("#888888")));
+            context.DrawText(overlayText,
+                new Point((bounds.Width - overlayText.Width) / 2,
+                          (bounds.Height - overlayText.Height) / 2));
+        }
     }
 
     private void DrawGrid(DrawingContext context, Rect area)
@@ -213,7 +241,7 @@ public class FanCurveChart : Control
     protected override void OnPointerPressed(PointerPressedEventArgs e)
     {
         base.OnPointerPressed(e);
-        if (CurveData is not { Length: 16 }) return;
+        if (CurveData is not { Length: 16 } || Disabled) return;
 
         var pos = e.GetPosition(this);
         var area = GetChartArea();

--- a/src/UI/Views/FansWindow.axaml
+++ b/src/UI/Views/FansWindow.axaml
@@ -15,7 +15,7 @@
 
         <!-- ═══════════════════ HEADER ═══════════════════ -->
         <Border Grid.Row="0" Classes="panel-header" Margin="10,10,10,5">
-            <Grid ColumnDefinitions="*,Auto,Auto,Auto">
+            <Grid ColumnDefinitions="*,Auto,Auto,Auto,Auto">
                 <StackPanel Grid.Column="0">
                     <TextBlock Classes="header" Text="Fan Curves" FontSize="14" />
                     <TextBlock x:Name="labelMode" Classes="label-dim"
@@ -27,7 +27,10 @@
                 <Button Grid.Column="2" x:Name="buttonReset" Classes="ghelper"
                         Content="Reset" Margin="4,0"
                         Click="ButtonReset_Click" />
-                <CheckBox Grid.Column="3" x:Name="checkApplyFans"
+                <Button Grid.Column="3" x:Name="buttonDisable" Classes="ghelper"
+                        Content="Disable" Margin="4,0"
+                        Click="ButtonDisable_Click" />
+                <CheckBox Grid.Column="4" x:Name="checkApplyFans"
                           Content="Auto-apply" Margin="8,0,0,0"
                           VerticalAlignment="Center"
                           Checked="CheckApplyFans_Changed"
@@ -36,7 +39,7 @@
         </Border>
 
         <!-- ═══════════════════ CHARTS ═══════════════════ -->
-        <Grid Grid.Row="1" Margin="10,5" RowDefinitions="*,*">
+        <Grid x:Name="chartGrid" Grid.Row="1" Margin="10,5" RowDefinitions="*,*,Auto">
             <!-- CPU Fan Chart -->
             <controls:FanCurveChart x:Name="chartCPU"
                                      Grid.Row="0"
@@ -50,6 +53,14 @@
                                      Margin="0,5,0,0"
                                      FanLabel="GPU Fan"
                                      LineColor="#FF2020" />
+
+            <!-- Mid Fan Chart (hidden by default, shown when mid fan detected) -->
+            <controls:FanCurveChart x:Name="chartMid"
+                                     Grid.Row="2"
+                                     Margin="0,5,0,0"
+                                     FanLabel="Mid Fan"
+                                     LineColor="#44DD44"
+                                     IsVisible="False" />
         </Grid>
 
         <!-- ═══════════════════ POWER LIMITS ═══════════════════ -->

--- a/src/UI/Views/FansWindow.axaml.cs
+++ b/src/UI/Views/FansWindow.axaml.cs
@@ -23,6 +23,7 @@ public partial class FansWindow : Window
         // Wire up curve change events
         chartCPU.CurveChanged += (_, curve) => OnCurveChanged(0, curve);
         chartGPU.CurveChanged += (_, curve) => OnCurveChanged(1, curve);
+        chartMid.CurveChanged += (_, curve) => OnCurveChanged(2, curve);
 
         _sensorTimer = new DispatcherTimer
         {
@@ -53,23 +54,50 @@ public partial class FansWindow : Window
         byte[]? cpuCurve = wmi.GetFanCurve(0);
         byte[]? gpuCurve = wmi.GetFanCurve(1);
 
-        // Fall back to config or defaults
-        if (cpuCurve == null || cpuCurve.Length != 16)
+        // Fall back to config or defaults if hardware returned no usable data
+        if (!IsValidCurve(cpuCurve))
         {
             cpuCurve = Helpers.AppConfig.GetFanConfig(0);
-            if (cpuCurve.Length != 16)
+            if (!IsValidCurve(cpuCurve))
                 cpuCurve = Helpers.AppConfig.GetDefaultCurve(0);
         }
 
-        if (gpuCurve == null || gpuCurve.Length != 16)
+        if (!IsValidCurve(gpuCurve))
         {
             gpuCurve = Helpers.AppConfig.GetFanConfig(1);
-            if (gpuCurve.Length != 16)
+            if (!IsValidCurve(gpuCurve))
                 gpuCurve = Helpers.AppConfig.GetDefaultCurve(1);
         }
 
         chartCPU.CurveData = cpuCurve;
         chartGPU.CurveData = gpuCurve;
+
+        // Mid fan detection — show chart if curve is valid or RPM is readable
+        // (matches Windows G-Helper's InitFans logic)
+        byte[]? midCurve = wmi.GetFanCurve(2);
+        bool hasMidFan = IsValidCurve(midCurve) || wmi.GetFanRpm(2) > 0;
+
+        if (hasMidFan)
+        {
+            if (!IsValidCurve(midCurve))
+            {
+                midCurve = Helpers.AppConfig.GetFanConfig(2);
+                if (!IsValidCurve(midCurve))
+                    midCurve = Helpers.AppConfig.GetDefaultCurve(2);
+            }
+
+            chartMid.CurveData = midCurve;
+            chartMid.IsVisible = true;
+            // Change third row from Auto to Star so all 3 charts share space equally
+            chartGrid.RowDefinitions[2].Height = new Avalonia.Controls.GridLength(1, Avalonia.Controls.GridUnitType.Star);
+            this.Height = 820;
+
+            Helpers.AppConfig.Set("mid_fan", 1);
+        }
+        else
+        {
+            Helpers.AppConfig.Set("mid_fan", 0);
+        }
 
         // Update mode label
         int mode = App.Wmi?.GetThrottleThermalPolicy() ?? -1;
@@ -83,6 +111,8 @@ public partial class FansWindow : Window
         labelMode.Text = $"Mode: {modeName}";
 
         checkApplyFans.IsChecked = Helpers.AppConfig.IsMode("auto_apply_fans");
+
+        UpdateDisabledState();
     }
 
     private void OnCurveChanged(int fanIndex, byte[] curve)
@@ -114,14 +144,85 @@ public partial class FansWindow : Window
             Helpers.AppConfig.SetFanConfig(1, chartGPU.CurveData);
         }
 
+        if (chartMid.IsVisible && chartMid.CurveData is { Length: 16 })
+        {
+            wmi.SetFanCurve(2, chartMid.CurveData);
+            Helpers.AppConfig.SetFanConfig(2, chartMid.CurveData);
+        }
+
+        UpdateDisabledState();
         Helpers.Logger.WriteLine("Fan curves applied");
     }
 
     private void ButtonReset_Click(object? sender, RoutedEventArgs e)
     {
-        chartCPU.CurveData = Helpers.AppConfig.GetDefaultCurve(0);
-        chartGPU.CurveData = Helpers.AppConfig.GetDefaultCurve(1);
-        Helpers.Logger.WriteLine("Fan curves reset to defaults");
+        var wmi = App.Wmi;
+
+        // Phase 1: Reset ALL fans to factory defaults (pwm_enable=3).
+        // Must do all resets before any re-apply because the kernel quirk
+        // causes pwm_enable=3 on one fan to reset ALL fans.
+        byte[]? cpuCurve = wmi?.ResetFanCurveToDefaults(0);
+        byte[]? gpuCurve = wmi?.ResetFanCurveToDefaults(1);
+        byte[]? midCurve = chartMid.IsVisible ? wmi?.ResetFanCurveToDefaults(2) : null;
+
+        // Fall back to hardcoded defaults if kernel reset unsupported
+        if (!IsValidCurve(cpuCurve))
+            cpuCurve = Helpers.AppConfig.GetDefaultCurve(0);
+        if (!IsValidCurve(gpuCurve))
+            gpuCurve = Helpers.AppConfig.GetDefaultCurve(1);
+        if (chartMid.IsVisible && !IsValidCurve(midCurve))
+            midCurve = Helpers.AppConfig.GetDefaultCurve(2);
+
+        // Phase 2: Update UI and save config
+        chartCPU.CurveData = cpuCurve;
+        chartGPU.CurveData = gpuCurve;
+        Helpers.AppConfig.SetFanConfig(0, cpuCurve!);
+        Helpers.AppConfig.SetFanConfig(1, gpuCurve!);
+
+        if (chartMid.IsVisible)
+        {
+            chartMid.CurveData = midCurve;
+            Helpers.AppConfig.SetFanConfig(2, midCurve!);
+        }
+
+        // Phase 3: Re-apply ALL curves as active custom curves (pwm_enable=1).
+        // Done after all resets so no subsequent pwm_enable=3 undoes them.
+        if (cpuCurve is { Length: 16 }) wmi?.SetFanCurve(0, cpuCurve);
+        if (gpuCurve is { Length: 16 }) wmi?.SetFanCurve(1, gpuCurve);
+        if (chartMid.IsVisible && midCurve is { Length: 16 }) wmi?.SetFanCurve(2, midCurve);
+
+        UpdateDisabledState();
+        Helpers.Logger.WriteLine("Fan curves reset to firmware defaults and re-applied");
+    }
+
+    private void ButtonDisable_Click(object? sender, RoutedEventArgs e)
+    {
+        var wmi = App.Wmi;
+        if (wmi == null) return;
+
+        wmi.DisableFanCurve(0);
+        wmi.DisableFanCurve(1);
+        if (chartMid.IsVisible) wmi.DisableFanCurve(2);
+        UpdateDisabledState();
+
+        Helpers.Logger.WriteLine("Custom fan curves disabled, using firmware defaults");
+    }
+
+    private void UpdateDisabledState()
+    {
+        var wmi = App.Wmi;
+        bool cpuEnabled = wmi?.IsFanCurveEnabled(0) ?? false;
+        bool gpuEnabled = wmi?.IsFanCurveEnabled(1) ?? false;
+        bool midEnabled = !chartMid.IsVisible || (wmi?.IsFanCurveEnabled(2) ?? false);
+        bool anyDisabled = !cpuEnabled || !gpuEnabled || !midEnabled;
+
+        chartCPU.Disabled = !cpuEnabled;
+        chartGPU.Disabled = !gpuEnabled;
+        if (chartMid.IsVisible) chartMid.Disabled = !midEnabled;
+
+        // Toggle button visual — accent border when disabled (active state)
+        buttonDisable.BorderBrush = anyDisabled ? AccentBrush : TransparentBrush;
+        buttonDisable.BorderThickness = new Avalonia.Thickness(2);
     }
 
     private void CheckApplyFans_Changed(object? sender, RoutedEventArgs e)
@@ -282,5 +383,24 @@ public partial class FansWindow : Window
         {
             Helpers.Logger.WriteLine("FansWindow sensor refresh error", ex);
         }
+    }
+
+    /// <summary>
+    /// Validate a fan curve read from hardware or config.
+    /// Rejects null, wrong length, and completely-zero curves.
+    /// Matches Windows G-Helper's IsEmptyCurve: a curve is invalid only if ALL 16 bytes are 0.
+    /// Note: CPU/GPU fan curves from the Linux kernel often have all-zero temperatures but
+    /// valid PWM duty cycles — these are valid curves (GetFanCurve synthesizes a temp ramp).
+    /// </summary>
+    private static bool IsValidCurve(byte[]? curve)
+    {
+        if (curve == null || curve.Length != 16) return false;
+
+        // Reject only if every byte is zero (no useful data at all)
+        for (int i = 0; i < 16; i++)
+        {
+            if (curve[i] > 0) return true;
+        }
+        return false;
     }
 }

--- a/src/USB/Aura.cs
+++ b/src/USB/Aura.cs
@@ -677,7 +677,22 @@ public static class Aura
     }
 
     /// <summary>
-    /// Check if AURA HID devices are available on this system.
+    /// Check if any AURA control path is available on this system.
+    /// Checks USB-HID, I2C-HID hidraw, and TUF kbd_rgb_mode sysfs.
+    /// The sysfs path is needed for TUF models where hid_asus isn't loaded
+    /// (e.g., kernel 6.19+ with asus_armoury, or I2C keyboards that don't
+    /// respond to HID AURA protocol like the FA608PP).
     /// </summary>
-    public static bool IsAvailable() => AsusHid.IsAvailable();
+    public static bool IsAvailable()
+    {
+        if (AsusHid.IsAvailable()) return true;
+
+        // TUF/VivoZenPro: kbd_rgb_mode sysfs works independently of HID
+        if (_isACPI)
+        {
+            var wmi = App.Wmi as Platform.Linux.LinuxAsusWmi;
+            if (wmi != null && wmi.HasKeyboardRgbMode()) return true;
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
Fixed:
- Remove incorrect millidegree conversion (kernel sysfs uses raw °C)
- Write pwm_enable=1 to enable custom curves (was writing 2=disable)
- Reorder SetFanCurve to write curve data before pwm_enable commit
- Synthesize temp ramp when kernel returns all-zero temperatures
- Validate curves properly: reject all-zero but accept zero-temp+valid-PWM
- Reset button resets all fans before re-applying to avoid kernel quirk where pwm_enable=3 on one fan resets all others

Added:
- Mid fan chart (green) — auto-detected via sysfs curve or RPM, window resizes to fit 3 charts when present, hidden on 2-fan machines
- Disable button with dark "Firmware control" overlay (pwm_enable=2)
- Reset loads real BIOS factory defaults via pwm_enable=3 instead of hardcoded fallback curves
- IsFanCurveEnabled/DisableFanCurve/ResetFanCurveToDefaults in WMI layer
- Aura.IsAvailable() checks TUF kbd_rgb_mode sysfs path
- Diagnostics: hid_asus module check, Aura.IsAvailable output