### PR TITLE
fix PPT power limits stuck on dual-backend kernels (asus-nb-wmi + asu…

### DIFF
--- a/install/90-ghelper.rules
+++ b/install/90-ghelper.rules
@@ -45,6 +45,13 @@ SUBSYSTEM=="platform", DRIVER=="asus-nb-wmi", \
   ATTR{ppt_platform_sppt}!="", \
   RUN+="/bin/chmod 0666 /sys/devices/platform/asus-nb-wmi/ppt_platform_sppt"
 
+# Fallback: batch-chmod ALL PPT attributes when asus-nb-wmi appears.
+# The ATTR{...}!="" condition above can miss attributes that appear slightly after the
+# platform device (timing race on dual-backend kernels with asus-armoury loaded).
+# This shell fallback catches any that were missed by the per-attribute rules.
+SUBSYSTEM=="platform", DRIVER=="asus-nb-wmi", \
+  RUN+="/bin/sh -c 'for attr in ppt_pl1_spl ppt_pl2_sppt ppt_fppt ppt_apu_sppt ppt_platform_sppt nv_dynamic_boost nv_temp_target; do [ -f /sys/devices/platform/asus-nb-wmi/$attr ] && chmod 0666 /sys/devices/platform/asus-nb-wmi/$attr; done'"
+
 # eGPU and boot sound
 SUBSYSTEM=="platform", DRIVER=="asus-nb-wmi", \
   ATTR{egpu_enable}!="", \
@@ -165,6 +172,12 @@ ACTION=="add|change", SUBSYSTEM=="module", KERNEL=="pcie_aspm", \
 # chmod all current_value files under the asus-armoury attributes dir.
 ACTION=="add|change", SUBSYSTEM=="firmware-attributes", \
   RUN+="/bin/sh -c 'for f in /sys/class/firmware-attributes/asus-armoury/attributes/*/current_value; do [ -f \"$f\" ] && chmod 0666 \"$f\"; done'"
+
+# Trigger on asus_armoury module load — the firmware-attributes subsystem event above
+# may fire before all attribute files are populated (race on fast kernels like CachyOS).
+# This module trigger provides a second chance with a brief delay.
+ACTION=="add|change", SUBSYSTEM=="module", KERNEL=="asus_armoury", \
+  RUN+="/bin/sh -c 'sleep 1; for f in /sys/class/firmware-attributes/asus-armoury/attributes/*/current_value; do [ -f \"$f\" ] && chmod 0666 \"$f\"; done'"
 
 # ── CPU online/offline (core toggling) ──
 SUBSYSTEM=="cpu", ACTION=="add", \

--- a/src/Mode/ModeControl.cs
+++ b/src/Mode/ModeControl.cs
@@ -28,8 +28,10 @@ public class ModeControl
         if (Helpers.AppConfig.IsX13()) return 75;
         if (Helpers.AppConfig.IsAlly()) return 50;
         if (Helpers.AppConfig.IsIntelHX()) return 175;
-        if (Helpers.AppConfig.IsAMDLight()) return 90;
+        // IsZ1325 must be checked before IsAMDLight: GZ302E matches both,
+        // but the Z13 2025 (GZ302EA) needs 93W max, not 90W.
         if (Helpers.AppConfig.IsZ1325()) return 93;
+        if (Helpers.AppConfig.IsAMDLight()) return 90;
         if (Helpers.AppConfig.IsFA401EA()) return 115;
         return 150; // default
     }
@@ -233,6 +235,35 @@ public class ModeControl
             Helpers.Logger.WriteLine($"AutoPower: PL2 = {pl2}W (max={maxTotal}W)");
         }
 
+        // APU SPPT / Platform SPPT — secondary AMD power tracking limits.
+        //
+        // On Windows, setting the ACPI thermal policy propagates internally to all PPT
+        // registers. On Linux with dual-backend kernels (asus-nb-wmi + asus-armoury),
+        // writing throttle_thermal_policy does NOT reliably update ppt_apu_sppt and
+        // ppt_platform_sppt — they can remain stuck at the previous mode's values
+        // (e.g. 5W from Silent mode) even after switching to Turbo.
+        //
+        // Since AMD firmware enforces min(all PPT limits), a 5W APU SPPT hard-caps
+        // performance regardless of PL1/PL2 being 93W. Mirror PL1/PL2 values here to
+        // ensure these secondary limits don't act as hidden bottlenecks.
+        //
+        // This matches asusctl's behavior of writing ALL PPT firmware-attributes.
+        int apuPlatCeiling = Math.Max(pl1, pl2);  // never less than either primary limit
+        if (apuPlatCeiling > 0)
+        {
+            if (wmi.IsFeatureSupported(Platform.Linux.AsusAttributes.PptApuSppt))
+            {
+                wmi.SetPptLimit(Platform.Linux.AsusAttributes.PptApuSppt, apuPlatCeiling);
+                Helpers.Logger.WriteLine($"AutoPower: APU SPPT = {apuPlatCeiling}W (mirrored from max(PL1,PL2))");
+            }
+
+            if (wmi.IsFeatureSupported(Platform.Linux.AsusAttributes.PptPlatformSppt))
+            {
+                wmi.SetPptLimit(Platform.Linux.AsusAttributes.PptPlatformSppt, apuPlatCeiling);
+                Helpers.Logger.WriteLine($"AutoPower: Platform SPPT = {apuPlatCeiling}W (mirrored from max(PL1,PL2))");
+            }
+        }
+
         // fPPT (fast boost)
         int fppt = Helpers.AppConfig.GetMode("limit_fppt");
         if (fppt > maxTotal || fppt < MinTotal) fppt = -1;
@@ -257,6 +288,62 @@ public class ModeControl
         if (nvTemp > 0 && wmi.IsFeatureSupported(Platform.Linux.AsusAttributes.NvTempTarget))
         {
             wmi.SetPptLimit(Platform.Linux.AsusAttributes.NvTempTarget, nvTemp);
+        }
+
+        // Verify PPT writes took effect — read back and warn on mismatches
+        VerifyPptLimits(wmi, pl1, pl2, fppt, apuPlatCeiling > 0 ? apuPlatCeiling : -1);
+    }
+
+    /// <summary>
+    /// Read back PPT values after writing to confirm they took effect.
+    /// Logs all current values and warns if any expected value doesn't match.
+    /// This helps diagnose dual-backend issues and permission problems.
+    /// </summary>
+    private static void VerifyPptLimits(Platform.IAsusWmi wmi, int expectedPl1, int expectedPl2, int expectedFppt, int expectedApuPlat)
+    {
+        try
+        {
+            // Brief delay to let writes settle through firmware
+            Thread.Sleep(200);
+
+            var checks = new List<(string name, Platform.Linux.AttrDef attr, int expected)>();
+            if (expectedPl1 > 0)
+                checks.Add(("PL1", Platform.Linux.AsusAttributes.PptPl1Spl, expectedPl1));
+            if (expectedPl2 > 0)
+                checks.Add(("PL2", Platform.Linux.AsusAttributes.PptPl2Sppt, expectedPl2));
+            if (expectedFppt > 0)
+                checks.Add(("fPPT", Platform.Linux.AsusAttributes.PptFppt, expectedFppt));
+            if (expectedApuPlat > 0)
+            {
+                checks.Add(("APU_SPPT", Platform.Linux.AsusAttributes.PptApuSppt, expectedApuPlat));
+                checks.Add(("PLAT_SPPT", Platform.Linux.AsusAttributes.PptPlatformSppt, expectedApuPlat));
+            }
+
+            var parts = new List<string>();
+            bool anyMismatch = false;
+
+            foreach (var (name, attr, expected) in checks)
+            {
+                int actual = wmi.GetPptLimit(attr);
+                string status;
+                if (actual < 0)
+                    status = "?";  // could not read back
+                else if (actual == expected)
+                    status = $"{actual}W";
+                else
+                {
+                    status = $"{actual}W (expected {expected}W!)";
+                    anyMismatch = true;
+                }
+                parts.Add($"{name}={status}");
+            }
+
+            string prefix = anyMismatch ? "WARNING AutoPower verify" : "AutoPower verify";
+            Helpers.Logger.WriteLine($"{prefix}: {string.Join(", ", parts)}");
+        }
+        catch (Exception ex)
+        {
+            Helpers.Logger.WriteLine("AutoPower verify failed", ex);
         }
     }
 }

--- a/src/Platform/Linux/LinuxAsusWmi.cs
+++ b/src/Platform/Linux/LinuxAsusWmi.cs
@@ -605,14 +605,33 @@ public class LinuxAsusWmi : IAsusWmi
 
     public void SetPptLimit(string attribute, int watts)
     {
-        // PPT attributes: ppt_pl1_spl, ppt_pl2_sppt, ppt_fppt, nv_dynamic_boost, nv_temp_target
-        var path = SysfsHelper.ResolveAttrPath(attribute, SysfsHelper.AsusWmiPlatform);
-        if (path != null)
-            SysfsHelper.WriteInt(path, watts);
+        // PPT attributes: ppt_pl1_spl, ppt_pl2_sppt, ppt_fppt, ppt_apu_sppt, etc.
+        //
+        // On dual-backend kernels (asus-nb-wmi + asus-armoury), we cannot predict which
+        // backend is functional for any given attribute. Write to ALL available paths —
+        // legacy sysfs and firmware-attributes — so at least one succeeds.
+        // See: https://github.com/utajum/g-helper-linux/issues/23
+        var attrDef = AsusAttributes.FindByLegacyName(attribute);
+        if (attrDef != null)
+        {
+            SysfsHelper.WriteToAllBackends(attrDef, watts.ToString(), SysfsHelper.AsusWmiPlatform);
+        }
+        else
+        {
+            // Fallback for unknown attributes: single resolved path
+            var path = SysfsHelper.ResolveAttrPath(attribute, SysfsHelper.AsusWmiPlatform);
+            if (path != null)
+                SysfsHelper.WriteInt(path, watts);
+        }
     }
 
     public int GetPptLimit(string attribute)
     {
+        // Read from the first available backend (legacy preferred for reliability)
+        var attrDef = AsusAttributes.FindByLegacyName(attribute);
+        if (attrDef != null)
+            return SysfsHelper.ReadFromAnyBackend(attrDef, -1, SysfsHelper.AsusWmiPlatform);
+
         var path = SysfsHelper.ResolveAttrPath(attribute, SysfsHelper.AsusWmiPlatform);
         if (path == null) return -1;
         return SysfsHelper.ReadInt(path, -1);

--- a/src/Platform/Linux/SysfsHelper.cs
+++ b/src/Platform/Linux/SysfsHelper.cs
@@ -156,6 +156,87 @@ public static class SysfsHelper
     }
 
     /// <summary>
+    /// Write a value to ALL available backends (legacy sysfs + firmware-attributes) for the
+    /// given attribute. Returns true if at least one write succeeded.
+    ///
+    /// Use this for PPT power limit writes where we cannot predict which backend is functional
+    /// on dual-backend kernels (asus-nb-wmi + asus-armoury loaded simultaneously).
+    /// On the reporter's GZ302EA, the firmware-attributes ppt_pl3_fppt path exists but
+    /// returns ENODEV/EACCES, while the legacy ppt_fppt works fine — and vice versa on
+    /// other machines.  Writing to both is the safest approach.
+    /// </summary>
+    public static bool WriteToAllBackends(AttrDef attr, string value, params string[] legacyBases)
+    {
+        if (legacyBases.Length == 0)
+            legacyBases = new[] { AsusWmiPlatform, AsusBusPlatform };
+
+        bool anySuccess = false;
+
+        // Try all legacy paths
+        foreach (var basePath in legacyBases)
+        {
+            var legacyPath = Path.Combine(basePath, attr.LegacyName);
+            if (WriteAttribute(legacyPath, value))
+                anySuccess = true;
+        }
+
+        // Try firmware-attributes path (using FwAttrName, which may differ from LegacyName)
+        var fwPath = Path.Combine(FirmwareAttributes, attr.FwAttrName, "current_value");
+        if (WriteAttribute(fwPath, value))
+            anySuccess = true;
+
+        // For aliased attrs (e.g. ppt_fppt → ppt_pl3_fppt), also try the legacy name
+        // under firmware-attributes in case the kernel uses that naming
+        if (attr.HasAlias)
+        {
+            var fwPathLegacy = Path.Combine(FirmwareAttributes, attr.LegacyName, "current_value");
+            if (fwPathLegacy != fwPath && WriteAttribute(fwPathLegacy, value))
+                anySuccess = true;
+        }
+
+        return anySuccess;
+    }
+
+    /// <summary>
+    /// Read from the first available backend (legacy sysfs or firmware-attributes) for the
+    /// given attribute. Returns the integer value or defaultValue if none could be read.
+    ///
+    /// Unlike WriteToAllBackends (which writes everywhere), reading only needs the first
+    /// successful result since they should all reflect the same hardware state.
+    /// </summary>
+    public static int ReadFromAnyBackend(AttrDef attr, int defaultValue = -1, params string[] legacyBases)
+    {
+        if (legacyBases.Length == 0)
+            legacyBases = new[] { AsusWmiPlatform, AsusBusPlatform };
+
+        // Try legacy paths first (more reliable on dual-backend systems)
+        foreach (var basePath in legacyBases)
+        {
+            var legacyPath = Path.Combine(basePath, attr.LegacyName);
+            var val = ReadInt(legacyPath, int.MinValue);
+            if (val != int.MinValue) return val;
+        }
+
+        // Try firmware-attributes
+        var fwPath = Path.Combine(FirmwareAttributes, attr.FwAttrName, "current_value");
+        var fwVal = ReadInt(fwPath, int.MinValue);
+        if (fwVal != int.MinValue) return fwVal;
+
+        // Aliased fallback
+        if (attr.HasAlias)
+        {
+            var fwPathLegacy = Path.Combine(FirmwareAttributes, attr.LegacyName, "current_value");
+            if (fwPathLegacy != fwPath)
+            {
+                var aliasVal = ReadInt(fwPathLegacy, int.MinValue);
+                if (aliasVal != int.MinValue) return aliasVal;
+            }
+        }
+
+        return defaultValue;
+    }
+
+    /// <summary>
     /// Log which backend was resolved for each known attribute (for diagnostics).
     /// </summary>
     public static void LogResolvedAttributes()

--- a/src/UI/Views/FansWindow.axaml.cs
+++ b/src/UI/Views/FansWindow.axaml.cs
@@ -287,6 +287,10 @@ public partial class FansWindow : Window
         labelPL1.Text = $"{watts}W";
         App.Wmi?.SetPptLimit(Platform.Linux.AsusAttributes.PptPl1Spl, watts);
         Helpers.AppConfig.SetMode("limit_slow", watts);
+
+        // Mirror to APU SPPT — prevents it from acting as a hidden power cap.
+        // Value = max(PL1, PL2) so neither primary limit is constrained.
+        MirrorToSecondaryPpt();
     }
 
     private void SliderPL2_ValueChanged(object? sender,
@@ -296,6 +300,33 @@ public partial class FansWindow : Window
         labelPL2.Text = $"{watts}W";
         App.Wmi?.SetPptLimit(Platform.Linux.AsusAttributes.PptPl2Sppt, watts);
         Helpers.AppConfig.SetMode("limit_fast", watts);
+
+        // Mirror to Platform SPPT — prevents it from acting as a hidden power cap.
+        MirrorToSecondaryPpt();
+    }
+
+    /// <summary>
+    /// Mirror PL1/PL2 values to secondary PPT attributes (APU SPPT, Platform SPPT).
+    /// These AMD power tracking limits act as hard caps — if left at stale values
+    /// (e.g. 5W from a previous Silent mode), they bottleneck performance regardless
+    /// of what PL1/PL2 are set to. We set both to max(PL1, PL2) so neither primary
+    /// limit is constrained by the secondary ones.
+    /// </summary>
+    private void MirrorToSecondaryPpt()
+    {
+        var wmi = App.Wmi;
+        if (wmi == null) return;
+
+        int pl1 = (int)sliderPL1.Value;
+        int pl2 = (int)sliderPL2.Value;
+        int ceiling = Math.Max(pl1, pl2);
+        if (ceiling <= 0) return;
+
+        if (wmi.IsFeatureSupported(Platform.Linux.AsusAttributes.PptApuSppt))
+            wmi.SetPptLimit(Platform.Linux.AsusAttributes.PptApuSppt, ceiling);
+
+        if (wmi.IsFeatureSupported(Platform.Linux.AsusAttributes.PptPlatformSppt))
+            wmi.SetPptLimit(Platform.Linux.AsusAttributes.PptPlatformSppt, ceiling);
     }
 
     private void SliderFppt_ValueChanged(object? sender,


### PR DESCRIPTION
…s-armoury)

FIXES:
- PPT power limits (PL1, PL2, fPPT) not applying on kernels with both asus-nb-wmi and asus-armoury loaded — writes now go to ALL available backends (legacy sysfs + firmware-attributes) so at least one succeeds
- Secondary AMD PPT limits (APU SPPT, Platform SPPT) stuck at stale values (e.g. 5W from Silent mode) after switching performance profiles — now mirrored from max(PL1, PL2) on every mode change and manual slider adjustment
- Udev race condition where asus-armoury firmware-attribute files aren't populated yet when the subsystem event fires — added fallback rule triggered on asus_armoury module load with a 1-second delay
- Udev race on asus-nb-wmi where per-attribute ATTR rules miss PPT files that appear slightly after the platform device — added shell fallback that batch-chmods all PPT attributes
- Model detection ordering: GZ302EA (Z13 2025) was matching IsAMDLight (90W) before IsZ1325 (93W) — reordered checks so specific model matches first

ADDED:
- SysfsHelper.WriteToAllBackends() — writes to every available backend path for a given attribute
- SysfsHelper.ReadFromAnyBackend() — reads from the first available backend path
- ModeControl.VerifyPptLimits() — post-write read-back verification with mismatch warnings in the log
- FansWindow.MirrorToSecondaryPpt() — mirrors manual PL1/PL2 slider changes to APU SPPT / Platform SPPT


https://github.com/utajum/g-helper-linux/issues/23