### PR TITLE
Bug fixes and improvements for TUF, Zephyrus G16, and display backlight

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       new_version: ${{ steps.version.outputs.new_version }}
+      prev_version: ${{ steps.version.outputs.prev_version }}
     steps:
       - name: Get latest release version from GitHub API
         id: version
@@ -28,6 +29,7 @@ jobs:
             LATEST_RELEASE=$(cat /tmp/latest_tag)
           fi
           echo "Latest release: '${LATEST_RELEASE}'"
+          echo "prev_version=${LATEST_RELEASE}" >> $GITHUB_OUTPUT
 
           if [ -z "$LATEST_RELEASE" ] || ! echo "$LATEST_RELEASE" | grep -qE '^v?[0-9]+\.[0-9]+\.[0-9]+$'; then
             NEW_VERSION="v1.0.0"
@@ -180,6 +182,24 @@ jobs:
           chmod +x release/GHelper-x86_64.AppImage
           ls -la release/
 
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate changelog from commits
+        id: changelog
+        run: |
+          PREV_TAG="${{ needs.version.outputs.prev_version }}"
+          if [ -n "$PREV_TAG" ]; then
+            CHANGELOG=$(git log ${PREV_TAG}..HEAD --pretty=format:"- %s" --no-merges | grep -iv '\[skip ci\]' || true)
+          else
+            CHANGELOG=$(git log --pretty=format:"- %s" --no-merges -20 | grep -iv '\[skip ci\]' || true)
+          fi
+          echo "changelog<<EOF" >> $GITHUB_OUTPUT
+          echo "$CHANGELOG" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
@@ -192,6 +212,9 @@ jobs:
             ![AppImage Downloads](https://img.shields.io/github/downloads/utajum/g-helper-linux/${{ needs.version.outputs.new_version }}/GHelper-x86_64.AppImage?style=flat-square&label=appimage%20downloads)
 
             ASUS laptop control utility for Linux — native AOT binary, no runtime needed.
+
+            ### Commits
+            ${{ steps.changelog.outputs.changelog }}
 
             ### Quick Install
 

--- a/.upstream-last-checked
+++ b/.upstream-last-checked
@@ -1,1 +1,1 @@
-46fe1e1bee91e1b0083cc18dac5a854d4b2d39bc
+67cbfada5cd34c56c5e76e5eee056ff2ce3e585f

--- a/src/App.axaml.cs
+++ b/src/App.axaml.cs
@@ -34,9 +34,6 @@ public class App : Application
     public static MainWindow? MainWindowInstance { get; set; }
     public static TrayIcon? TrayIconInstance { get; set; }
 
-    //startup via environment variable GHELPER_SILENT_START=1
-    private static bool IsSilentStartup() => Environment.GetEnvironmentVariable("GHELPER_SILENT_START") == "1";
-
     // Single-instance lock that prevents duplicate tray icons
     private static FileStream? _lockFile;
 
@@ -108,8 +105,8 @@ public class App : Application
             MainWindowInstance = new MainWindow();
             if (AppConfig.Is("topmost")) MainWindowInstance.Topmost = true;
 
-            // Show main window on startup (like Windows G-Helper) & skipped if GHELPER_SILENT_START=1
-            if (!IsSilentStartup())
+            // Show main window on startup unless "Start minimized to tray" is enabled
+            if (!AppConfig.Is("silent_start"))
             {
                 desktop.MainWindow = MainWindowInstance;
             }
@@ -139,6 +136,12 @@ public class App : Application
                     "udev rules not installed. Run install.sh for full functionality (battery limit, fan control, etc.)",
                     "dialog-warning");
             }
+
+            // Initialize AURA hardware (RGB) on background thread regardless of window visibility.
+            Task.Run(() => MainWindow.InitAuraHardware());
+
+            // Always ensure autostart .desktop file exists with correct binary path
+            System?.SetAutostart(true);
 
             // Update tray icon to match current mode
             UpdateTrayIcon();

--- a/src/App.axaml.cs
+++ b/src/App.axaml.cs
@@ -806,7 +806,10 @@ public class App : Application
             }
 
             Avalonia.Threading.Dispatcher.UIThread.Post(() =>
-                MainWindowInstance?.RefreshGpuModePublic());
+            {
+                MainWindowInstance?.RefreshGpuModePublic();
+                MainWindowInstance?.RefreshBatteryPublic();
+            });
         });
 
         // Auto performance mode (if configured)

--- a/src/App.axaml.cs
+++ b/src/App.axaml.cs
@@ -34,6 +34,9 @@ public class App : Application
     public static MainWindow? MainWindowInstance { get; set; }
     public static TrayIcon? TrayIconInstance { get; set; }
 
+    //startup via environment variable GHELPER_SILENT_START=1
+    private static bool IsSilentStartup() => Environment.GetEnvironmentVariable("GHELPER_SILENT_START") == "1";
+
     // Single-instance lock that prevents duplicate tray icons
     private static FileStream? _lockFile;
 
@@ -105,8 +108,11 @@ public class App : Application
             MainWindowInstance = new MainWindow();
             if (AppConfig.Is("topmost")) MainWindowInstance.Topmost = true;
 
-            // Show main window on startup (like Windows G-Helper)
-            desktop.MainWindow = MainWindowInstance;
+            // Show main window on startup (like Windows G-Helper) & skipped if GHELPER_SILENT_START=1
+            if (!IsSilentStartup())
+            {
+                desktop.MainWindow = MainWindowInstance;
+            }
 
             // Set up tray icon (secondary access method)
             SetupTrayIcon(desktop);

--- a/src/App.axaml.cs
+++ b/src/App.axaml.cs
@@ -140,8 +140,9 @@ public class App : Application
             // Initialize AURA hardware (RGB) on background thread regardless of window visibility.
             Task.Run(() => MainWindow.InitAuraHardware());
 
-            // Always ensure autostart .desktop file exists with correct binary path
-            System?.SetAutostart(true);
+            // Ensure autostart .desktop file matches config preference and current binary path
+            bool autostart = AppConfig.IsNotFalse("autostart");
+            System?.SetAutostart(autostart);
 
             // Update tray icon to match current mode
             UpdateTrayIcon();

--- a/src/Mode/ModeControl.cs
+++ b/src/Mode/ModeControl.cs
@@ -130,7 +130,13 @@ public class ModeControl
             }
         }
 
-        // 4. Apply fan curves and power limits
+        // 4. Apply power limits, ASPM, then fan curves LAST
+        // Fan curves must be written after everything else because:
+        //   - AutoPower writes nv_dynamic_boost/nv_temp_target which can cause the EC
+        //     to recalculate GPU fan strategy and override custom curves
+        //   - ASPM policy changes trigger PCIe link renegotiation which can reset curves
+        //   - The kernel resets fan curves when thermal profile changes (asusctl documents this)
+        // By writing curves last, nothing runs after them to reset them.
         Task.Run(async () =>
         {
             // If reset was needed, wait for firmware to process the bounce
@@ -138,10 +144,6 @@ public class ModeControl
                 await Task.Delay(1500);
             else
                 await Task.Delay(100); // Let thermal policy settle
-
-            AutoFans(mode);
-
-            await Task.Delay(500);
 
             AutoPower(mode);
 
@@ -157,6 +159,10 @@ public class ModeControl
             {
                 App.Power?.SetAspmPolicy(baseMode == 2 ? "powersave" : "default");
             }
+
+            await Task.Delay(100); // Let EC settle after power/ASPM changes
+
+            AutoFans(mode);
         });
 
         if (notify)

--- a/src/Mode/ModeControl.cs
+++ b/src/Mode/ModeControl.cs
@@ -198,7 +198,8 @@ public class ModeControl
         var wmi = App.Wmi;
         if (wmi == null) return;
 
-        for (int fan = 0; fan < 3; fan++)
+        int fanCount = wmi.FanCount;
+        for (int fan = 0; fan < fanCount; fan++)
         {
             byte[] curve = Helpers.AppConfig.GetFanConfig(fan);
             if (curve.Length == 16)

--- a/src/Platform/IAsusWmi.cs
+++ b/src/Platform/IAsusWmi.cs
@@ -129,6 +129,9 @@ public interface IAsusWmi : IDisposable
 
     // ── Feature detection ──
 
+    /// <summary>Number of controllable fans (2 = CPU+GPU, 3 = CPU+GPU+Mid).</summary>
+    int FanCount { get; }
+
     /// <summary>Check if a sysfs attribute exists (feature is supported).</summary>
     bool IsFeatureSupported(string feature);
 

--- a/src/Platform/Linux/LinuxAsusWmi.cs
+++ b/src/Platform/Linux/LinuxAsusWmi.cs
@@ -36,6 +36,8 @@ public class LinuxAsusWmi : IAsusWmi
     private volatile bool _eventListening;
     private readonly List<FileStream> _eventStreams = new();  // Track open evdev streams for Dispose()
 
+    public int FanCount { get; private set; } = 2;
+
     public event Action<int>? WmiEvent;
 
     public LinuxAsusWmi()
@@ -75,7 +77,16 @@ public class LinuxAsusWmi : IAsusWmi
             Helpers.Logger.WriteLine("WARNING: No hwmon with fan*_input found. Fan RPM unavailable.");
 
         if (_asusFanCurveHwmonDir != null)
+        {
             Helpers.Logger.WriteLine($"ASUS fan curve hwmon: {_asusFanCurveHwmonDir}");
+            // Detect fan count: pwm1/pwm2 always present, pwm3 only on 3-fan models.
+            // Some kernels create phantom pwm3 files that exist but return ENODEV on write,
+            // so we verify by reading pwm3_enable (read won't error on phantom nodes).
+            FanCount = File.Exists(Path.Combine(_asusFanCurveHwmonDir, "pwm3_enable"))
+                    && SysfsHelper.ReadInt(Path.Combine(_asusFanCurveHwmonDir, "pwm3_enable"), -1) >= 0
+                    ? 3 : 2;
+            Helpers.Logger.WriteLine($"Fan count detected: {FanCount}");
+        }
         else
             Helpers.Logger.WriteLine("WARNING: ASUS fan curve hwmon not found. Fan curve features unavailable.");
 

--- a/src/Platform/Linux/LinuxDisplayControl.cs
+++ b/src/Platform/Linux/LinuxDisplayControl.cs
@@ -15,27 +15,80 @@ namespace GHelper.Linux.Platform.Linux;
 /// </summary>
 public class LinuxDisplayControl : IDisplayControl
 {
+    /// <summary>Minimum brightness percentage — prevents screen from going fully black.</summary>
+    public const int MinBrightnessPercent = 4;
+
     private string? _backlightDir;
     private int _maxBrightness;
     private bool _isWayland;
 
     public LinuxDisplayControl()
     {
-        _backlightDir = FindBestBacklight();
+        InitBacklight();
         _isWayland = IsWaylandSession();
-
-        if (_backlightDir != null)
-        {
-            _maxBrightness = SysfsHelper.ReadInt(
-                Path.Combine(_backlightDir, "max_brightness"), 100);
-            Helpers.Logger.WriteLine($"Backlight found: {_backlightDir} (max={_maxBrightness})");
-        }
-        else
-        {
-            Helpers.Logger.WriteLine("WARNING: No backlight device found. Brightness control unavailable.");
-        }
-
         Helpers.Logger.WriteLine($"Display session type: {(_isWayland ? "Wayland" : "X11")}");
+    }
+
+    /// <summary>True when a /sys/class/backlight/ device is available.</summary>
+    public bool HasBacklight => _backlightDir != null && _maxBrightness > 0;
+
+    // ── Backlight module detection ──
+
+    /// <summary>
+    /// When no backlight device exists, detect which kernel module could provide one.
+    /// Returns the module name (e.g. "nvidia-wmi-ec-backlight") or null if no loadable fix.
+    /// </summary>
+    public static string? GetMissingBacklightModule()
+    {
+        // Only NVIDIA has a standalone backlight module that isn't auto-loaded.
+        // Intel (i915) and AMD (amdgpu) build backlight support into the GPU driver itself.
+        if (Directory.Exists("/sys/module/nvidia"))
+        {
+            // Check if the module exists in the kernel tree
+            string? modinfo = SysfsHelper.RunCommand("modinfo", "nvidia-wmi-ec-backlight");
+            if (modinfo != null)
+                return "nvidia-wmi-ec-backlight";
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Human-readable hint when no backlight device exists and no module can be loaded.
+    /// </summary>
+    public static string GetBacklightHint()
+    {
+        if (Directory.Exists("/sys/module/nvidia"))
+            return "NVIDIA GPU detected but no backlight module available.\nTry kernel parameter: acpi_backlight=native";
+        if (Directory.Exists("/sys/module/i915"))
+            return "Intel GPU detected but no backlight registered.\nTry: acpi_backlight=native or i915.enable_dpcd_backlight=1";
+        if (Directory.Exists("/sys/module/amdgpu"))
+            return "AMD GPU detected but no backlight registered.\nTry kernel parameter: acpi_backlight=native";
+
+        return "No backlight device found.";
+    }
+
+    /// <summary>
+    /// Load the given backlight kernel module via pkexec and re-scan for backlight devices.
+    /// Returns true if a backlight device is now available.
+    /// </summary>
+    public bool TryLoadBacklightModule(string moduleName)
+    {
+        Helpers.Logger.WriteLine($"Backlight: loading module {moduleName} via pkexec...");
+        SysfsHelper.RunPkexecBash($"modprobe {moduleName}");
+
+        // Give the kernel a moment to register the sysfs node
+        Thread.Sleep(1000);
+
+        InitBacklight();
+        if (HasBacklight)
+        {
+            Helpers.Logger.WriteLine($"Backlight: module loaded, device found: {_backlightDir} (max={_maxBrightness})");
+            return true;
+        }
+
+        Helpers.Logger.WriteLine($"Backlight: module loaded but no backlight device appeared.");
+        return false;
     }
 
     // ── Brightness ──
@@ -55,11 +108,29 @@ public class LinuxDisplayControl : IDisplayControl
     {
         if (_backlightDir == null || _maxBrightness <= 0) return;
 
-        percent = Math.Clamp(percent, 0, 100);
+        percent = Math.Clamp(percent, MinBrightnessPercent, 100);
         int rawValue = (int)Math.Round(percent * _maxBrightness / 100.0);
 
         SysfsHelper.WriteInt(
             Path.Combine(_backlightDir, "brightness"), rawValue);
+    }
+
+    // ── Init helpers ──
+
+    private void InitBacklight()
+    {
+        _backlightDir = FindBestBacklight();
+        if (_backlightDir != null)
+        {
+            _maxBrightness = SysfsHelper.ReadInt(
+                Path.Combine(_backlightDir, "max_brightness"), 100);
+            Helpers.Logger.WriteLine($"Backlight found: {_backlightDir} (max={_maxBrightness})");
+        }
+        else
+        {
+            _maxBrightness = 0;
+            Helpers.Logger.WriteLine("WARNING: No backlight device found. Brightness control unavailable.");
+        }
     }
 
     // ── Refresh Rate ──

--- a/src/UI/Views/ExtraWindow.axaml
+++ b/src/UI/Views/ExtraWindow.axaml
@@ -104,17 +104,28 @@
                         <TextBlock Classes="header" Text="Display" />
                     </Border>
 
-                    <!-- Brightness -->
-                    <Grid ColumnDefinitions="120,*,50" Margin="0,4">
+                    <!-- Brightness slider (visible when backlight device exists) -->
+                    <Grid x:Name="rowBrightnessSlider" ColumnDefinitions="120,*,50" Margin="0,4">
                         <TextBlock Grid.Column="0" Text="Brightness"
                                    Classes="label-dim" VerticalAlignment="Center" />
                         <Slider Grid.Column="1" x:Name="sliderBrightness"
-                                Minimum="0" Maximum="100" Value="100"
+                                Minimum="4" Maximum="100" Value="100"
                                 ValueChanged="SliderBrightness_ValueChanged" />
                         <TextBlock Grid.Column="2" x:Name="labelBrightness"
                                    Classes="value" Text="100%"
                                    HorizontalAlignment="Center" VerticalAlignment="Center" />
                     </Grid>
+
+                    <!-- Backlight enable button (visible when no backlight + loadable module) -->
+                    <Button x:Name="buttonEnableBacklight"
+                            Content="Enable display backlight"
+                            IsVisible="False" Margin="0,4"
+                            Click="ButtonEnableBacklight_Click" />
+
+                    <!-- Backlight hint (visible when no backlight + no loadable module) -->
+                    <TextBlock x:Name="labelBacklightHint"
+                               IsVisible="False" Classes="label-dim"
+                               Margin="0,4" TextWrapping="Wrap" FontSize="11" />
 
                     <!-- Panel Overdrive -->
                     <CheckBox x:Name="checkOverdrive" Content="Panel Overdrive"

--- a/src/UI/Views/ExtraWindow.axaml
+++ b/src/UI/Views/ExtraWindow.axaml
@@ -169,6 +169,11 @@
                               Checked="CheckClamshell_Changed"
                               Unchecked="CheckClamshell_Changed" />
 
+                    <CheckBox x:Name="checkSilentStart" Content="Start minimized to tray"
+                              Margin="0,4"
+                              Checked="CheckSilentStart_Changed"
+                              Unchecked="CheckSilentStart_Changed" />
+
                     <Separator Margin="0,8,0,4" />
 
                     <!-- Device toggles -->

--- a/src/UI/Views/ExtraWindow.axaml.cs
+++ b/src/UI/Views/ExtraWindow.axaml.cs
@@ -283,6 +283,9 @@ public partial class ExtraWindow : Window
         // Clamshell mode
         checkClamshell.IsChecked = Helpers.AppConfig.Is("toggle_clamshell_mode");
 
+        // Silent start (minimized to tray)
+        checkSilentStart.IsChecked = Helpers.AppConfig.Is("silent_start");
+
         // Camera
         checkCamera.IsChecked = LinuxSystemIntegration.IsCameraEnabled();
 
@@ -382,6 +385,12 @@ public partial class ExtraWindow : Window
         {
             Helpers.Logger.WriteLine($"Clamshell mode toggle failed: {ex.Message}");
         }
+    }
+
+    private void CheckSilentStart_Changed(object? sender, RoutedEventArgs e)
+    {
+        if (_suppressEvents) return;
+        Helpers.AppConfig.Set("silent_start", (checkSilentStart.IsChecked ?? false) ? 1 : 0);
     }
 
     /// <summary>Start a systemd-inhibit process that prevents lid-close suspend.</summary>

--- a/src/UI/Views/ExtraWindow.axaml.cs
+++ b/src/UI/Views/ExtraWindow.axaml.cs
@@ -217,22 +217,83 @@ public partial class ExtraWindow : Window
 
     // ═══════════════════ DISPLAY ═══════════════════
 
+    /// <summary>Module name stored when the enable-backlight button is shown.</summary>
+    private string? _pendingBacklightModule;
+
     private void RefreshDisplay()
     {
-        var display = App.Display;
+        var display = App.Display as LinuxDisplayControl;
         if (display == null) return;
 
-        int brightness = display.GetBrightness();
-        if (brightness >= 0)
+        if (display.HasBacklight)
         {
-            sliderBrightness.Value = brightness;
-            labelBrightness.Text = $"{brightness}%";
+            // Backlight available — show slider, hide button/hint
+            rowBrightnessSlider.IsVisible = true;
+            buttonEnableBacklight.IsVisible = false;
+            labelBacklightHint.IsVisible = false;
+
+            int brightness = display.GetBrightness();
+            if (brightness >= 0)
+            {
+                sliderBrightness.Value = Math.Max(brightness, LinuxDisplayControl.MinBrightnessPercent);
+                labelBrightness.Text = $"{brightness}%";
+            }
+        }
+        else
+        {
+            // No backlight — hide slider, check if we can offer a fix
+            rowBrightnessSlider.IsVisible = false;
+
+            _pendingBacklightModule = LinuxDisplayControl.GetMissingBacklightModule();
+            if (_pendingBacklightModule != null)
+            {
+                buttonEnableBacklight.Content = $"Enable display backlight (load {_pendingBacklightModule})";
+                buttonEnableBacklight.IsVisible = true;
+                buttonEnableBacklight.IsEnabled = true;
+                labelBacklightHint.IsVisible = false;
+            }
+            else
+            {
+                buttonEnableBacklight.IsVisible = false;
+                labelBacklightHint.Text = LinuxDisplayControl.GetBacklightHint();
+                labelBacklightHint.IsVisible = true;
+            }
         }
 
         bool overdrive = App.Wmi?.GetPanelOverdrive() ?? false;
         checkOverdrive.IsChecked = overdrive;
 
         sliderGamma.Value = 100; // Default gamma
+    }
+
+    private void ButtonEnableBacklight_Click(object? sender, RoutedEventArgs e)
+    {
+        if (_pendingBacklightModule == null) return;
+
+        string module = _pendingBacklightModule;
+        buttonEnableBacklight.Content = "Loading...";
+        buttonEnableBacklight.IsEnabled = false;
+
+        // Run modprobe on background thread (pkexec shows password dialog)
+        Task.Run(() =>
+        {
+            var display = App.Display as LinuxDisplayControl;
+            bool success = display?.TryLoadBacklightModule(module) ?? false;
+
+            Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+            {
+                _suppressEvents = true;
+                RefreshDisplay();
+                _suppressEvents = false;
+
+                if (!success)
+                {
+                    buttonEnableBacklight.IsVisible = false;
+                    labelBacklightHint.Text = $"Failed to enable backlight. Module loaded but no device appeared.\n{LinuxDisplayControl.GetBacklightHint()}";
+                    labelBacklightHint.IsVisible = true;
+                }
+            });
+        });
     }
 
     private void SliderBrightness_ValueChanged(object? sender,

--- a/src/UI/Views/FansWindow.axaml.cs
+++ b/src/UI/Views/FansWindow.axaml.cs
@@ -290,6 +290,9 @@ public partial class FansWindow : Window
     {
         if (_updatingPLSliders) return;
         labelPL1.Text = $"{(int)e.NewValue}W";
+        // Enforce PL1 ≤ PL2 ≤ fPPT (matches Windows G-Helper coupling)
+        if (sliderPL1.Value > sliderPL2.Value) sliderPL2.Value = sliderPL1.Value;
+        if (sliderPL1.Value > sliderFppt.Value) sliderFppt.Value = sliderPL1.Value;
         SchedulePLWrite();
     }
 
@@ -298,6 +301,8 @@ public partial class FansWindow : Window
     {
         if (_updatingPLSliders) return;
         labelPL2.Text = $"{(int)e.NewValue}W";
+        if (sliderPL2.Value < sliderPL1.Value) sliderPL1.Value = sliderPL2.Value;
+        if (sliderPL2.Value > sliderFppt.Value) sliderFppt.Value = sliderPL2.Value;
         SchedulePLWrite();
     }
 
@@ -306,6 +311,8 @@ public partial class FansWindow : Window
     {
         if (_updatingPLSliders) return;
         labelFppt.Text = $"{(int)e.NewValue}W";
+        if (sliderFppt.Value < sliderPL2.Value) sliderPL2.Value = sliderFppt.Value;
+        if (sliderFppt.Value < sliderPL1.Value) sliderPL1.Value = sliderFppt.Value;
         SchedulePLWrite();
     }
 

--- a/src/UI/Views/FansWindow.axaml.cs
+++ b/src/UI/Views/FansWindow.axaml.cs
@@ -15,6 +15,8 @@ public partial class FansWindow : Window
     private static readonly IBrush TransparentBrush = Brushes.Transparent;
 
     private readonly DispatcherTimer _sensorTimer;
+    private System.Timers.Timer? _plDebounce;
+    private bool _updatingPLSliders;
 
     public FansWindow()
     {
@@ -244,6 +246,8 @@ public partial class FansWindow : Window
         var wmi = App.Wmi;
         if (wmi == null) return;
 
+        _updatingPLSliders = true;
+
         // Read from hardware, fall back to saved config
         int pl1 = wmi.GetPptLimit(Platform.Linux.AsusAttributes.PptPl1Spl);
         if (pl1 <= 0) pl1 = Helpers.AppConfig.GetMode("limit_slow");
@@ -277,65 +281,78 @@ public partial class FansWindow : Window
             }
         }
 
+        _updatingPLSliders = false;
         checkApplyPower.IsChecked = Helpers.AppConfig.IsMode("auto_apply_power");
     }
 
     private void SliderPL1_ValueChanged(object? sender,
         Avalonia.Controls.Primitives.RangeBaseValueChangedEventArgs e)
     {
-        int watts = (int)e.NewValue;
-        labelPL1.Text = $"{watts}W";
-        App.Wmi?.SetPptLimit(Platform.Linux.AsusAttributes.PptPl1Spl, watts);
-        Helpers.AppConfig.SetMode("limit_slow", watts);
-
-        // Mirror to APU SPPT — prevents it from acting as a hidden power cap.
-        // Value = max(PL1, PL2) so neither primary limit is constrained.
-        MirrorToSecondaryPpt();
+        if (_updatingPLSliders) return;
+        labelPL1.Text = $"{(int)e.NewValue}W";
+        SchedulePLWrite();
     }
 
     private void SliderPL2_ValueChanged(object? sender,
         Avalonia.Controls.Primitives.RangeBaseValueChangedEventArgs e)
     {
-        int watts = (int)e.NewValue;
-        labelPL2.Text = $"{watts}W";
-        App.Wmi?.SetPptLimit(Platform.Linux.AsusAttributes.PptPl2Sppt, watts);
-        Helpers.AppConfig.SetMode("limit_fast", watts);
-
-        // Mirror to Platform SPPT — prevents it from acting as a hidden power cap.
-        MirrorToSecondaryPpt();
-    }
-
-    /// <summary>
-    /// Mirror PL1/PL2 values to secondary PPT attributes (APU SPPT, Platform SPPT).
-    /// These AMD power tracking limits act as hard caps — if left at stale values
-    /// (e.g. 5W from a previous Silent mode), they bottleneck performance regardless
-    /// of what PL1/PL2 are set to. We set both to max(PL1, PL2) so neither primary
-    /// limit is constrained by the secondary ones.
-    /// </summary>
-    private void MirrorToSecondaryPpt()
-    {
-        var wmi = App.Wmi;
-        if (wmi == null) return;
-
-        int pl1 = (int)sliderPL1.Value;
-        int pl2 = (int)sliderPL2.Value;
-        int ceiling = Math.Max(pl1, pl2);
-        if (ceiling <= 0) return;
-
-        if (wmi.IsFeatureSupported(Platform.Linux.AsusAttributes.PptApuSppt))
-            wmi.SetPptLimit(Platform.Linux.AsusAttributes.PptApuSppt, ceiling);
-
-        if (wmi.IsFeatureSupported(Platform.Linux.AsusAttributes.PptPlatformSppt))
-            wmi.SetPptLimit(Platform.Linux.AsusAttributes.PptPlatformSppt, ceiling);
+        if (_updatingPLSliders) return;
+        labelPL2.Text = $"{(int)e.NewValue}W";
+        SchedulePLWrite();
     }
 
     private void SliderFppt_ValueChanged(object? sender,
         Avalonia.Controls.Primitives.RangeBaseValueChangedEventArgs e)
     {
-        int watts = (int)e.NewValue;
-        labelFppt.Text = $"{watts}W";
-        App.Wmi?.SetPptLimit(Platform.Linux.AsusAttributes.PptFppt, watts);
-        Helpers.AppConfig.SetMode("limit_fppt", watts);
+        if (_updatingPLSliders) return;
+        labelFppt.Text = $"{(int)e.NewValue}W";
+        SchedulePLWrite();
+    }
+
+    /// <summary>Debounce PL slider writes — only write 300ms after the user stops dragging.</summary>
+    private void SchedulePLWrite()
+    {
+        _plDebounce?.Stop();
+        _plDebounce ??= new System.Timers.Timer(300) { AutoReset = false };
+        _plDebounce.Elapsed -= PLDebounce_Elapsed;
+        _plDebounce.Elapsed += PLDebounce_Elapsed;
+        _plDebounce.Start();
+    }
+
+    private void PLDebounce_Elapsed(object? sender, System.Timers.ElapsedEventArgs e)
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            var wmi = App.Wmi;
+            if (wmi == null) return;
+
+            int pl1 = (int)sliderPL1.Value;
+            int pl2 = (int)sliderPL2.Value;
+            int fppt = (int)sliderFppt.Value;
+
+            wmi.SetPptLimit(Platform.Linux.AsusAttributes.PptPl1Spl, pl1);
+            Helpers.AppConfig.SetMode("limit_slow", pl1);
+
+            wmi.SetPptLimit(Platform.Linux.AsusAttributes.PptPl2Sppt, pl2);
+            Helpers.AppConfig.SetMode("limit_fast", pl2);
+
+            if (gridFppt.IsVisible)
+            {
+                wmi.SetPptLimit(Platform.Linux.AsusAttributes.PptFppt, fppt);
+                Helpers.AppConfig.SetMode("limit_fppt", fppt);
+            }
+
+            // Mirror to secondary PPT — prevents stale APU/Platform SPPT
+            // from bottlenecking. Value = max(PL1, PL2).
+            int ceiling = Math.Max(pl1, pl2);
+            if (ceiling > 0)
+            {
+                if (wmi.IsFeatureSupported(Platform.Linux.AsusAttributes.PptApuSppt))
+                    wmi.SetPptLimit(Platform.Linux.AsusAttributes.PptApuSppt, ceiling);
+                if (wmi.IsFeatureSupported(Platform.Linux.AsusAttributes.PptPlatformSppt))
+                    wmi.SetPptLimit(Platform.Linux.AsusAttributes.PptPlatformSppt, ceiling);
+            }
+        });
     }
 
     // ── CPU Boost ──

--- a/src/UI/Views/MainWindow.axaml.cs
+++ b/src/UI/Views/MainWindow.axaml.cs
@@ -1155,9 +1155,9 @@ public partial class MainWindow : Window
         // Version + model in footer
         labelVersion.Text = $"v{Helpers.AppConfig.AppVersion} — {model}";
 
-        // Check autostart status (suppress to avoid re-writing .desktop file)
+        // Check autostart status from config (suppress to avoid re-writing .desktop file)
         _suppressEvents = true;
-        checkStartup.IsChecked = sys.IsAutostartEnabled();
+        checkStartup.IsChecked = Helpers.AppConfig.IsNotFalse("autostart");
         _suppressEvents = false;
 
         // System info (same as ExtraWindow)
@@ -1190,6 +1190,7 @@ public partial class MainWindow : Window
     {
         if (_suppressEvents) return;
         bool enabled = checkStartup.IsChecked ?? false;
+        Helpers.AppConfig.Set("autostart", enabled ? 1 : 0);
         App.System?.SetAutostart(enabled);
     }
 

--- a/src/UI/Views/MainWindow.axaml.cs
+++ b/src/UI/Views/MainWindow.axaml.cs
@@ -18,6 +18,7 @@ namespace GHelper.Linux.UI.Views;
 public partial class MainWindow : Window
 {
     private readonly DispatcherTimer _refreshTimer;
+    private int _batteryRefreshCounter;
     private int _currentPerfMode = -1;
     private int _currentGpuMode = -1;  // 0=Eco, 1=Standard, 2=Optimized (auto), 3=Ultimate (MUX=0)
 
@@ -37,7 +38,16 @@ public partial class MainWindow : Window
         {
             Interval = TimeSpan.FromSeconds(2)
         };
-        _refreshTimer.Tick += (_, _) => RefreshSensorData();
+        _refreshTimer.Tick += (_, _) =>
+        {
+            RefreshSensorData();
+            // Refresh battery every ~60s (30 ticks × 2s)
+            if (++_batteryRefreshCounter >= 30)
+            {
+                _batteryRefreshCounter = 0;
+                RefreshBattery();
+            }
+        };
 
         // On close: let the window actually close (dispose).
         // Don't cancel — this allows KDE logout/reboot to proceed.
@@ -200,6 +210,7 @@ public partial class MainWindow : Window
 
     /// <summary>Public wrapper for RefreshGpuMode — called from App.cs on power state changes.</summary>
     public void RefreshGpuModePublic() => RefreshGpuMode();
+    public void RefreshBatteryPublic() => RefreshBattery();
 
     private void RefreshGpuMode()
     {

--- a/src/UI/Views/MainWindow.axaml.cs
+++ b/src/UI/Views/MainWindow.axaml.cs
@@ -49,11 +49,13 @@ public partial class MainWindow : Window
             App.MainWindowInstance = null;
         };
 
-        // Initial load
+        // Start sensor refresh timer immediately (works even in tray-only mode)
+        _refreshTimer.Start();
+
+        // Populate UI controls when the window becomes visible
         Loaded += (_, _) =>
         {
             RefreshAll();
-            _refreshTimer.Start();
         };
     }
 
@@ -657,7 +659,9 @@ public partial class MainWindow : Window
     // ── Keyboard / AURA ──
 
     private bool _auraInitialized = false;
+    private static bool _auraHardwareInitialized = false;
     private bool _suppressAuraEvents = false;
+    private bool _suppressEvents = false;
 
     public void RefreshKeyboard()
     {
@@ -681,18 +685,18 @@ public partial class MainWindow : Window
         InitAura();
     }
 
-    private void InitAura()
+    /// <summary>
+    /// Initialize AURA hardware — HID handshake, load config, apply RGB.
+    /// </summary>
+    public static bool InitAuraHardware()
     {
-        if (_auraInitialized) return;
-        _auraInitialized = true;
+        if (_auraHardwareInitialized) return Aura.IsAvailable();
+        _auraHardwareInitialized = true;
 
-        bool hasAura = Aura.IsAvailable();
-        panelAura.IsVisible = hasAura;
-
-        if (!hasAura)
+        if (!Aura.IsAvailable())
         {
             Helpers.Logger.WriteLine("No AURA HID device found — RGB controls hidden");
-            return;
+            return false;
         }
 
         Helpers.Logger.WriteLine("AURA HID device found — initializing RGB controls");
@@ -710,12 +714,21 @@ public partial class MainWindow : Window
         Aura.SetColor2(Helpers.AppConfig.Get("aura_color2", 0));
 
         // Apply saved power state + mode so the keyboard lights up on startup
-        // (runs on background thread after config values are loaded above)
-        Task.Run(() =>
-        {
-            Aura.ApplyPower();
-            Aura.ApplyAura();
-        });
+        Aura.ApplyPower();
+        Aura.ApplyAura();
+
+        return true;
+    }
+
+    private void InitAura()
+    {
+        if (_auraInitialized) return;
+        _auraInitialized = true;
+
+        // Run hardware init if not already done (normal startup path)
+        bool hasAura = InitAuraHardware();
+        panelAura.IsVisible = hasAura;
+        if (!hasAura) return;
 
         _suppressAuraEvents = true;
 
@@ -1142,8 +1155,10 @@ public partial class MainWindow : Window
         // Version + model in footer
         labelVersion.Text = $"v{Helpers.AppConfig.AppVersion} — {model}";
 
-        // Check autostart status
+        // Check autostart status (suppress to avoid re-writing .desktop file)
+        _suppressEvents = true;
         checkStartup.IsChecked = sys.IsAutostartEnabled();
+        _suppressEvents = false;
 
         // System info (same as ExtraWindow)
         labelSysModel.Text = $"Model: {model}";
@@ -1173,6 +1188,7 @@ public partial class MainWindow : Window
 
     private void CheckStartup_Changed(object? sender, RoutedEventArgs e)
     {
+        if (_suppressEvents) return;
         bool enabled = checkStartup.IsChecked ?? false;
         App.System?.SetAutostart(enabled);
     }

--- a/src/USB/Aura.cs
+++ b/src/USB/Aura.cs
@@ -299,6 +299,10 @@ public static class Aura
         else
             AsusHid.Write(new byte[] { AsusHid.AURA_ID, 0xBA, 0xC5, 0xC4, (byte)brightness }, log);
 
+        // TUF/VivoZenPro: also write sysfs brightness (HID may not be available)
+        if (_isACPI)
+            App.Wmi?.SetKeyboardBrightness(brightness);
+
         if (brightness > 0)
         {
             if (!_backlight) _initDirect = true;


### PR DESCRIPTION
## Summary

Fixes several issues reported on TUF and Zephyrus G16 hardware, adds quality-of-life features for power limit sliders and battery monitoring, and introduces display backlight module detection for NVIDIA hybrid GPU laptops.

## Bug Fixes

- **Keyboard brightness on TUF/VivoZenPro** — `ApplyBrightness()` now falls back to ACPI sysfs write when HID is unavailable (#50)
- **PL slider spam on Zephyrus G16** — Added 300ms shared debounce timer for PL1/PL2/fPPT sliders (#47)
- **Fan count detection** — Dynamically detect 2 vs 3 fans instead of hardcoding 3, fixes `pwm3_enable` ENODEV errors (#47)
- **Display backlight on NVIDIA hybrid GPUs** — When `/sys/class/backlight/` is empty, detect and offer to load `nvidia-wmi-ec-backlight` via pkexec. Shows kernel parameter hints for Intel/AMD. Minimum brightness clamped to 4% to prevent black screen (#50)

## Features

- **Battery auto-refresh** — Battery drain/charge info refreshes every 60s and immediately on AC plug/unplug (#35)
- **PL slider coupling** — Enforces PL1 ≤ PL2 ≤ fPPT, matching Windows G-Helper behavior (#35)
- **Start minimized to tray** — New checkbox in settings, plus autostart .desktop file management

## Internal

- Reorder application of power limits, ASPM, and fan curves on mode change