### PR TITLE
Fallback calculation of battery drain rate

### DIFF
--- a/src/Platform/Linux/LinuxPowerManager.cs
+++ b/src/Platform/Linux/LinuxPowerManager.cs
@@ -203,14 +203,25 @@ public class LinuxPowerManager : IPowerManager
         if (_batteryDir == null) return -1;
         return SysfsHelper.ReadInt(Path.Combine(_batteryDir, "capacity"), -1);
     }
-
+    
     public int GetBatteryDrainRate()
     {
         if (_batteryDir == null) return 0;
 
         // power_now is in microwatts
-        int powerUw = SysfsHelper.ReadInt(Path.Combine(_batteryDir, "power_now"), 0);
-        int powerMw = powerUw / 1000;
+        int powerMw = 0;
+        if (File.Exists(Path.Combine(_batteryDir, "power_now")))
+        {
+            int powerUw = SysfsHelper.ReadInt(Path.Combine(_batteryDir, "power_now"), 0);
+            powerMw = powerUw / 1000;
+        }
+        // calculates power using current and voltage, if power isn't available
+        else if (File.Exists(Path.Combine(_batteryDir, "current_now")) && File.Exists(Path.Combine(_batteryDir, "voltage_now")))
+        {
+            long currentUa = SysfsHelper.ReadInt(Path.Combine(_batteryDir, "current_now"), 0);
+            long voltageUv = SysfsHelper.ReadInt(Path.Combine(_batteryDir, "voltage_now"), 0);
+            powerMw = (int) ((currentUa * voltageUv) / 1_000_000_000L);
+        }
 
         var status = SysfsHelper.ReadAttribute(Path.Combine(_batteryDir, "status"));
         // Return positive for discharging, negative for charging


### PR DESCRIPTION
Hi there! This is my first time ever contributing to an open-source project, so sorry if I did something wrong.

On my laptop, I was never able to get the charging/discharging rate to show up when using the program. I did a little bit of experimentation, and I found that the `power_now` file the program draws the power draw from is not on my system for some reason. To get around this, I added a fallback: if the `power_now` file is not found, it will instead try calculate the power draw using `current_now` and `voltage_now`. This seems to be roughly equivalent to the "rate" displayed in the "Power Statistics" Gnome application.

If I did something wrong or something that I wasn't supposed to, feel free to correct me.