### PR TITLE
Added ryzen CO undervolting via ryzen_smu driver (raphael / dragon range)

### DIFF
--- a/install/90-ghelper.rules
+++ b/install/90-ghelper.rules
@@ -183,6 +183,12 @@ ACTION=="add|change", SUBSYSTEM=="firmware-attributes", \
 ACTION=="add|change", SUBSYSTEM=="module", KERNEL=="asus_armoury", \
   RUN+="/bin/sh -c 'sleep 1; for f in /sys/class/firmware-attributes/asus-armoury/attributes/*/current_value; do [ -f \"$f\" ] && chmod 0666 \"$f\"; done'"
 
+# ── ryzen_smu (Curve Optimizer undervolting) ──
+# Only rsmu_cmd and smu_args need write access for sending CO commands.
+# Other attributes (codename, version, pm_table, …) remain read-only.
+ACTION=="add|change", SUBSYSTEM=="module", KERNEL=="ryzen_smu", \
+  RUN+="/bin/sh -c 'chmod 0666 /sys/kernel/ryzen_smu_drv/rsmu_cmd /sys/kernel/ryzen_smu_drv/smu_args 2>/dev/null || true'"
+
 # ── CPU online/offline (core toggling) ──
 SUBSYSTEM=="cpu", ACTION=="add", \
   RUN+="/bin/sh -c 'for f in /sys/devices/system/cpu/cpu*/online; do [ -f \"$f\" ] && chmod 0666 \"$f\"; done'"

--- a/src/App.axaml.cs
+++ b/src/App.axaml.cs
@@ -25,6 +25,7 @@ public class App : Application
     public static IAudioControl? Audio { get; private set; }
     public static IDisplayControl? Display { get; private set; }
     public static IGpuControl? GpuControl { get; private set; }
+    public static RyzenSmu? Smu { get; private set; }
 
     // GPU mode switching controller (safety checks, driver detection, reboot scheduling)
     public static GpuModeController? GpuModeCtrl { get; private set; }
@@ -281,6 +282,11 @@ public class App : Application
         Input = new LinuxInputHandler();
         Audio = new LinuxAudioControl();
         Display = new LinuxDisplayControl();
+
+        Smu = new RyzenSmu();
+        Logger.WriteLine(Smu.IsAvailable
+            ? "Ryzen Curve Optimizer: available via ryzen_smu driver"
+            : $"Ryzen Curve Optimizer: unavailable ({Smu.UnavailableReason})");
 
         // Create mode controller (uses App.Wmi, App.Power, etc.)
         Mode = new ModeControl();

--- a/src/I18n/Languages/Arabic.cs
+++ b/src/I18n/Languages/Arabic.cs
@@ -307,6 +307,12 @@ public static class Arabic
         ["firmware_control"] = "التحكم بالبرنامج الثابت",
         ["fan_sensor_format"] = "CPU: {0} / GPU: {1} الحمل: {2}   الوسطى: {3} RPM",
 
+        // UNDERVOLTING
+        ["undervolt_header"] = "خفض الجهد (تجريبي)",
+        ["undervolt_desc"] = "إزاحة Curve Optimizer. القيم الأكثر سلبية = جهد أقل. القيم المنخفضة جداً قد تسبب عدم استقرار أو تلف البيانات. ابدأ بقيم صغيرة. يُعاد الضبط عند إعادة التشغيل.",
+        ["undervolt_cpu"] = "CPU",
+        ["undervolt_auto_apply"] = "تطبيق تلقائي عند تغيير الوضع",
+
         // BATTERY INFO WINDOW
         ["battery_info_title"] = "معلومات البطارية",
         ["health_header"] = "الصحة",

--- a/src/I18n/Languages/ChineseSimplified.cs
+++ b/src/I18n/Languages/ChineseSimplified.cs
@@ -307,6 +307,12 @@ public static class ChineseSimplified
         ["firmware_control"] = "固件控制",
         ["fan_sensor_format"] = "CPU：{0} / GPU：{1} 负载：{2}   中间：{3} RPM",
 
+        // UNDERVOLTING
+        ["undervolt_header"] = "降压（实验性）",
+        ["undervolt_desc"] = "Curve Optimizer 偏移。值越负 = 电压越低。值过低可能导致不稳定或数据损坏。从小值开始。重启后重置。",
+        ["undervolt_cpu"] = "CPU",
+        ["undervolt_auto_apply"] = "模式切换时自动应用",
+
         // BATTERY INFO WINDOW
         ["battery_info_title"] = "电池信息",
         ["health_header"] = "健康状况",

--- a/src/I18n/Languages/ChineseTraditional.cs
+++ b/src/I18n/Languages/ChineseTraditional.cs
@@ -307,6 +307,12 @@ public static class ChineseTraditional
         ["firmware_control"] = "韌體控制",
         ["fan_sensor_format"] = "CPU：{0} / GPU：{1} 負載：{2}   中間：{3} RPM",
 
+        // UNDERVOLTING
+        ["undervolt_header"] = "降壓（實驗性）",
+        ["undervolt_desc"] = "Curve Optimizer 偏移。值越負 = 電壓越低。值過低可能導致不穩定或資料損毀。從小值開始。重啟後重置。",
+        ["undervolt_cpu"] = "CPU",
+        ["undervolt_auto_apply"] = "模式切換時自動套用",
+
         // BATTERY INFO WINDOW
         ["battery_info_title"] = "電池資訊",
         ["health_header"] = "健康狀況",

--- a/src/I18n/Languages/Czech.cs
+++ b/src/I18n/Languages/Czech.cs
@@ -304,6 +304,12 @@ public static class Czech
         ["firmware_control"] = "Ovládání firmwaru",
         ["fan_sensor_format"] = "CPU: {0} / GPU: {1} Zátěž: {2}   Střed.: {3} RPM",
 
+        // UNDERVOLTING
+        ["undervolt_header"] = "Podpětí (experimentální)",
+        ["undervolt_desc"] = "Offset Curve Optimizeru. Více záporné = nižší napětí. Příliš nízké hodnoty mohou způsobit nestabilitu nebo poškození dat. Začněte s malými. Resetuje se při restartu.",
+        ["undervolt_cpu"] = "CPU",
+        ["undervolt_auto_apply"] = "Automaticky použít při změně režimu",
+
         // BATTERY INFO WINDOW
         ["battery_info_title"] = "Informace o baterii",
         ["health_header"] = "Zdraví",

--- a/src/I18n/Languages/Danish.cs
+++ b/src/I18n/Languages/Danish.cs
@@ -307,6 +307,12 @@ public static class Danish
         ["firmware_control"] = "Firmware-styring",
         ["fan_sensor_format"] = "CPU: {0} / GPU: {1} Last: {2}   Midt: {3} RPM",
 
+        // UNDERVOLTING
+        ["undervolt_header"] = "Undervolting (eksperimentel)",
+        ["undervolt_desc"] = "Curve Optimizer-offset. Mere negativ = lavere spænding. For lave værdier kan forårsage ustabilitet eller datakorruption. Start småt. Nulstilles ved genstart.",
+        ["undervolt_cpu"] = "CPU",
+        ["undervolt_auto_apply"] = "Anvend automatisk ved tilstandsændring",
+
         // BATTERY INFO WINDOW
         ["battery_info_title"] = "Batterioplysninger",
         ["health_header"] = "Sundhed",

--- a/src/I18n/Languages/Dutch.cs
+++ b/src/I18n/Languages/Dutch.cs
@@ -304,6 +304,12 @@ public static class Dutch
         ["firmware_control"] = "Firmwarebesturing",
         ["fan_sensor_format"] = "CPU: {0} / GPU: {1} Belasting: {2}   Midden: {3} RPM",
 
+        // UNDERVOLTING
+        ["undervolt_header"] = "Undervolting (Experimenteel)",
+        ["undervolt_desc"] = "Curve Optimizer-offset. Negatiever = lagere spanning. Te lage waarden kunnen instabiliteit of datacorruptie veroorzaken. Begin klein. Wordt gereset bij herstart.",
+        ["undervolt_cpu"] = "CPU",
+        ["undervolt_auto_apply"] = "Automatisch toepassen bij moduswissel",
+
         // BATTERY INFO WINDOW
         ["battery_info_title"] = "Accu-informatie",
         ["health_header"] = "Gezondheid",

--- a/src/I18n/Languages/English.cs
+++ b/src/I18n/Languages/English.cs
@@ -309,6 +309,12 @@ public static class English
         ["firmware_control"] = "Firmware control",
         ["fan_sensor_format"] = "CPU: {0} / GPU: {1} Load: {2}   Mid: {3} RPM",
 
+        // UNDERVOLTING
+        ["undervolt_header"] = "Undervolting (Experimental)",
+        ["undervolt_desc"] = "Curve Optimizer offset. More negative = lower voltage. Too-low values can cause instability or data corruption. Start small. Resets on reboot.",
+        ["undervolt_cpu"] = "CPU",
+        ["undervolt_auto_apply"] = "Auto-apply on mode change",
+
         // BATTERY INFO WINDOW
         ["battery_info_title"] = "Battery Information",
         ["health_header"] = "Health",

--- a/src/I18n/Languages/Finnish.cs
+++ b/src/I18n/Languages/Finnish.cs
@@ -307,6 +307,12 @@ public static class Finnish
         ["firmware_control"] = "Firmware-ohjaus",
         ["fan_sensor_format"] = "CPU: {0} / GPU: {1} Kuorma: {2}   Keski: {3} RPM",
 
+        // UNDERVOLTING
+        ["undervolt_header"] = "Alijännite (kokeellinen)",
+        ["undervolt_desc"] = "Curve Optimizer -siirtymä. Negatiivisempi = matalampi jännite. Liian matalat arvot voivat aiheuttaa epävakautta tai tietojen vioittumista. Aloita pienestä. Palautuu uudelleenkäynnistyksessä.",
+        ["undervolt_cpu"] = "CPU",
+        ["undervolt_auto_apply"] = "Käytä automaattisesti tilan vaihtuessa",
+
         // BATTERY INFO WINDOW
         ["battery_info_title"] = "Akkutiedot",
         ["health_header"] = "Kunto",

--- a/src/I18n/Languages/French.cs
+++ b/src/I18n/Languages/French.cs
@@ -304,6 +304,12 @@ public static class French
         ["firmware_control"] = "Contrôle firmware",
         ["fan_sensor_format"] = "CPU : {0} / GPU : {1} Charge : {2}   Central : {3} RPM",
 
+        // UNDERVOLTING
+        ["undervolt_header"] = "Undervolting (Expérimental)",
+        ["undervolt_desc"] = "Décalage Curve Optimizer. Plus négatif = tension plus basse. Des valeurs trop basses peuvent provoquer instabilité ou corruption de données. Commencez petit. Réinitialisé au redémarrage.",
+        ["undervolt_cpu"] = "CPU",
+        ["undervolt_auto_apply"] = "Appliquer automatiquement au changement de mode",
+
         // BATTERY INFO WINDOW
         ["battery_info_title"] = "Informations batterie",
         ["health_header"] = "Santé",

--- a/src/I18n/Languages/German.cs
+++ b/src/I18n/Languages/German.cs
@@ -304,6 +304,12 @@ public static class German
         ["firmware_control"] = "Firmware-Steuerung",
         ["fan_sensor_format"] = "CPU: {0} / GPU: {1} Last: {2}   Mittel: {3} RPM",
 
+        // UNDERVOLTING
+        ["undervolt_header"] = "Undervolting (Experimentell)",
+        ["undervolt_desc"] = "Curve-Optimizer-Offset. Negativer = niedrigere Spannung. Zu niedrige Werte können Instabilität oder Datenverlust verursachen. Klein anfangen. Setzt sich beim Neustart zurück.",
+        ["undervolt_cpu"] = "CPU",
+        ["undervolt_auto_apply"] = "Bei Moduswechsel automatisch anwenden",
+
         // BATTERY INFO WINDOW
         ["battery_info_title"] = "Akku-Informationen",
         ["health_header"] = "Zustand",

--- a/src/I18n/Languages/Greek.cs
+++ b/src/I18n/Languages/Greek.cs
@@ -307,6 +307,12 @@ public static class Greek
         ["firmware_control"] = "Έλεγχος firmware",
         ["fan_sensor_format"] = "CPU: {0} / GPU: {1} Φορτίο: {2}   Μεσαίος: {3} RPM",
 
+        // UNDERVOLTING
+        ["undervolt_header"] = "Undervolting (Πειραματικό)",
+        ["undervolt_desc"] = "Αντιστάθμιση Curve Optimizer. Πιο αρνητικό = χαμηλότερη τάση. Πολύ χαμηλές τιμές μπορεί να προκαλέσουν αστάθεια ή καταστροφή δεδομένων. Ξεκινήστε με μικρές. Επαναφέρεται στην επανεκκίνηση.",
+        ["undervolt_cpu"] = "CPU",
+        ["undervolt_auto_apply"] = "Αυτόματη εφαρμογή στην αλλαγή λειτουργίας",
+
         // BATTERY INFO WINDOW
         ["battery_info_title"] = "Πληροφορίες μπαταρίας",
         ["health_header"] = "Υγεία",

--- a/src/I18n/Languages/Hungarian.cs
+++ b/src/I18n/Languages/Hungarian.cs
@@ -304,6 +304,12 @@ public static class Hungarian
         ["firmware_control"] = "Firmware vezérlés",
         ["fan_sensor_format"] = "CPU: {0} / GPU: {1} Terhelés: {2}   Közép: {3} RPM",
 
+        // UNDERVOLTING
+        ["undervolt_header"] = "Alulfeszültség (kísérleti)",
+        ["undervolt_desc"] = "Curve Optimizer eltolás. Negatívabb = alacsonyabb feszültség. Túl alacsony értékek instabilitást vagy adatsérülést okozhatnak. Kis értékkel kezdje. Újraindításkor visszaáll.",
+        ["undervolt_cpu"] = "CPU",
+        ["undervolt_auto_apply"] = "Automatikus alkalmazás módváltáskor",
+
         // BATTERY INFO WINDOW
         ["battery_info_title"] = "Akkumulátor információ",
         ["health_header"] = "Állapot",

--- a/src/I18n/Languages/Indonesian.cs
+++ b/src/I18n/Languages/Indonesian.cs
@@ -307,6 +307,12 @@ public static class Indonesian
         ["firmware_control"] = "Kontrol firmware",
         ["fan_sensor_format"] = "CPU: {0} / GPU: {1} Beban: {2}   Tengah: {3} RPM",
 
+        // UNDERVOLTING
+        ["undervolt_header"] = "Undervolting (Eksperimental)",
+        ["undervolt_desc"] = "Offset Curve Optimizer. Lebih negatif = voltase lebih rendah. Nilai terlalu rendah bisa menyebabkan ketidakstabilan atau kerusakan data. Mulai dari kecil. Direset saat reboot.",
+        ["undervolt_cpu"] = "CPU",
+        ["undervolt_auto_apply"] = "Terapkan otomatis saat ganti mode",
+
         // BATTERY INFO WINDOW
         ["battery_info_title"] = "Informasi Baterai",
         ["health_header"] = "Kesehatan",

--- a/src/I18n/Languages/Italian.cs
+++ b/src/I18n/Languages/Italian.cs
@@ -304,6 +304,12 @@ public static class Italian
         ["firmware_control"] = "Controllo firmware",
         ["fan_sensor_format"] = "CPU: {0} / GPU: {1} Carico: {2}   Centrale: {3} RPM",
 
+        // UNDERVOLTING
+        ["undervolt_header"] = "Undervolting (Sperimentale)",
+        ["undervolt_desc"] = "Offset Curve Optimizer. Più negativo = voltaggio più basso. Valori troppo bassi possono causare instabilità o corruzione dei dati. Inizia con valori piccoli. Si azzera al riavvio.",
+        ["undervolt_cpu"] = "CPU",
+        ["undervolt_auto_apply"] = "Applica automaticamente al cambio modalità",
+
         // BATTERY INFO WINDOW
         ["battery_info_title"] = "Informazioni batteria",
         ["health_header"] = "Salute",

--- a/src/I18n/Languages/Japanese.cs
+++ b/src/I18n/Languages/Japanese.cs
@@ -307,6 +307,12 @@ public static class Japanese
         ["firmware_control"] = "ファームウェア制御",
         ["fan_sensor_format"] = "CPU: {0} / GPU: {1} 負荷: {2}   中間: {3} RPM",
 
+        // UNDERVOLTING
+        ["undervolt_header"] = "アンダーボルト（実験的）",
+        ["undervolt_desc"] = "Curve Optimizer オフセット。より負の値 = より低い電圧。値が低すぎると不安定やデータ破損の原因になります。小さな値から始めてください。再起動でリセットされます。",
+        ["undervolt_cpu"] = "CPU",
+        ["undervolt_auto_apply"] = "モード変更時に自動適用",
+
         // BATTERY INFO WINDOW
         ["battery_info_title"] = "バッテリー情報",
         ["health_header"] = "健康状態",

--- a/src/I18n/Languages/Korean.cs
+++ b/src/I18n/Languages/Korean.cs
@@ -307,6 +307,12 @@ public static class Korean
         ["firmware_control"] = "펌웨어 제어",
         ["fan_sensor_format"] = "CPU: {0} / GPU: {1} 부하: {2}   중간: {3} RPM",
 
+        // UNDERVOLTING
+        ["undervolt_header"] = "언더볼팅 (실험적)",
+        ["undervolt_desc"] = "Curve Optimizer 오프셋. 더 음수 = 더 낮은 전압. 너무 낮은 값은 불안정 또는 데이터 손상을 일으킬 수 있습니다. 작은 값부터 시작하세요. 재부팅 시 초기화됩니다.",
+        ["undervolt_cpu"] = "CPU",
+        ["undervolt_auto_apply"] = "모드 변경 시 자동 적용",
+
         // BATTERY INFO WINDOW
         ["battery_info_title"] = "배터리 정보",
         ["health_header"] = "건강 상태",

--- a/src/I18n/Languages/Macedonian.cs
+++ b/src/I18n/Languages/Macedonian.cs
@@ -307,6 +307,12 @@ public static class Macedonian
         ["firmware_control"] = "Контрола на фирмвер",
         ["fan_sensor_format"] = "CPU: {0} / GPU: {1} Оптеретување: {2}   Среден: {3} RPM",
 
+        // UNDERVOLTING
+        ["undervolt_header"] = "Undervolting (Експериментално)",
+        ["undervolt_desc"] = "Curve Optimizer офсет. Понегативно = понизок напон. Премногу ниски вредности може да предизвикаат нестабилност или оштетување на податоци. Почнете со мали. Се ресетира при рестарт.",
+        ["undervolt_cpu"] = "CPU",
+        ["undervolt_auto_apply"] = "Автоматски примени при промена на режим",
+
         // BATTERY INFO WINDOW
         ["battery_info_title"] = "Информации за батерија",
         ["health_header"] = "Здравје",

--- a/src/I18n/Languages/Norwegian.cs
+++ b/src/I18n/Languages/Norwegian.cs
@@ -307,6 +307,12 @@ public static class Norwegian
         ["firmware_control"] = "Firmware-kontroll",
         ["fan_sensor_format"] = "CPU: {0} / GPU: {1} Last: {2}   Midt: {3} RPM",
 
+        // UNDERVOLTING
+        ["undervolt_header"] = "Undervolting (eksperimentelt)",
+        ["undervolt_desc"] = "Curve Optimizer-forskyvning. Mer negativt = lavere spenning. For lave verdier kan forårsake ustabilitet eller datakorrupsjon. Start lite. Tilbakestilles ved omstart.",
+        ["undervolt_cpu"] = "CPU",
+        ["undervolt_auto_apply"] = "Bruk automatisk ved modusendring",
+
         // BATTERY INFO WINDOW
         ["battery_info_title"] = "Batteriinformasjon",
         ["health_header"] = "Helse",

--- a/src/I18n/Languages/Polish.cs
+++ b/src/I18n/Languages/Polish.cs
@@ -304,6 +304,12 @@ public static class Polish
         ["firmware_control"] = "Kontrola firmware",
         ["fan_sensor_format"] = "CPU: {0} / GPU: {1} Obciążenie: {2}   Środ.: {3} RPM",
 
+        // UNDERVOLTING
+        ["undervolt_header"] = "Undervolting (eksperymentalny)",
+        ["undervolt_desc"] = "Przesunięcie Curve Optimizer. Bardziej ujemne = niższe napięcie. Zbyt niskie wartości mogą powodować niestabilność lub uszkodzenie danych. Zacznij od małych. Resetuje się po restarcie.",
+        ["undervolt_cpu"] = "CPU",
+        ["undervolt_auto_apply"] = "Automatycznie stosuj przy zmianie trybu",
+
         // BATTERY INFO WINDOW
         ["battery_info_title"] = "Informacje o baterii",
         ["health_header"] = "Kondycja",

--- a/src/I18n/Languages/PortugueseBR.cs
+++ b/src/I18n/Languages/PortugueseBR.cs
@@ -304,6 +304,12 @@ public static class PortugueseBR
         ["firmware_control"] = "Controle de firmware",
         ["fan_sensor_format"] = "CPU: {0} / GPU: {1} Carga: {2}   Central: {3} RPM",
 
+        // UNDERVOLTING
+        ["undervolt_header"] = "Undervolting (Experimental)",
+        ["undervolt_desc"] = "Offset do Curve Optimizer. Mais negativo = tensão menor. Valores muito baixos podem causar instabilidade ou corrupção de dados. Comece pequeno. Redefinido ao reiniciar.",
+        ["undervolt_cpu"] = "CPU",
+        ["undervolt_auto_apply"] = "Aplicar automaticamente ao mudar modo",
+
         // BATTERY INFO WINDOW
         ["battery_info_title"] = "Informações da bateria",
         ["health_header"] = "Saúde",

--- a/src/I18n/Languages/Romanian.cs
+++ b/src/I18n/Languages/Romanian.cs
@@ -304,6 +304,12 @@ public static class Romanian
         ["firmware_control"] = "Control firmware",
         ["fan_sensor_format"] = "CPU: {0} / GPU: {1} Încărcare: {2}   Mijloc: {3} RPM",
 
+        // UNDERVOLTING
+        ["undervolt_header"] = "Undervolting (experimental)",
+        ["undervolt_desc"] = "Offset Curve Optimizer. Mai negativ = tensiune mai mică. Valorile prea mici pot cauza instabilitate sau coruperea datelor. Începe cu valori mici. Se resetează la repornire.",
+        ["undervolt_cpu"] = "CPU",
+        ["undervolt_auto_apply"] = "Aplică automat la schimbarea modului",
+
         // BATTERY INFO WINDOW
         ["battery_info_title"] = "Informații baterie",
         ["health_header"] = "Sănătate",

--- a/src/I18n/Languages/Russian.cs
+++ b/src/I18n/Languages/Russian.cs
@@ -304,6 +304,12 @@ public static class Russian
         ["firmware_control"] = "Управление прошивкой",
         ["fan_sensor_format"] = "CPU: {0} / GPU: {1} Нагрузка: {2}   Средний: {3} RPM",
 
+        // UNDERVOLTING
+        ["undervolt_header"] = "Андервольтинг (экспериментально)",
+        ["undervolt_desc"] = "Смещение Curve Optimizer. Более отрицательное = меньшее напряжение. Слишком низкие значения могут вызвать нестабильность или повреждение данных. Начинайте с малого. Сбрасывается при перезагрузке.",
+        ["undervolt_cpu"] = "CPU",
+        ["undervolt_auto_apply"] = "Автоматически применять при смене режима",
+
         // BATTERY INFO WINDOW
         ["battery_info_title"] = "Информация о батарее",
         ["health_header"] = "Здоровье",

--- a/src/I18n/Languages/Serbian.cs
+++ b/src/I18n/Languages/Serbian.cs
@@ -307,6 +307,12 @@ public static class Serbian
         ["firmware_control"] = "Контрола фирмвера",
         ["fan_sensor_format"] = "CPU: {0} / GPU: {1} Оптерећење: {2}   Средњи: {3} RPM",
 
+        // UNDERVOLTING
+        ["undervolt_header"] = "Андерволтинг (експериментално)",
+        ["undervolt_desc"] = "Curve Optimizer офсет. Негативније = нижи напон. Превише ниске вредности могу изазвати нестабилност или оштећење података. Почните са малим. Ресетује се при рестарту.",
+        ["undervolt_cpu"] = "CPU",
+        ["undervolt_auto_apply"] = "Аутоматски примени при промени режима",
+
         // BATTERY INFO WINDOW
         ["battery_info_title"] = "Информације о батерији",
         ["health_header"] = "Здравље",

--- a/src/I18n/Languages/Spanish.cs
+++ b/src/I18n/Languages/Spanish.cs
@@ -304,6 +304,12 @@ public static class Spanish
         ["firmware_control"] = "Control de firmware",
         ["fan_sensor_format"] = "CPU: {0} / GPU: {1} Carga: {2}   Central: {3} RPM",
 
+        // UNDERVOLTING
+        ["undervolt_header"] = "Undervolting (Experimental)",
+        ["undervolt_desc"] = "Offset de Curve Optimizer. Más negativo = menor voltaje. Valores demasiado bajos pueden causar inestabilidad o corrupción de datos. Empieza con poco. Se restablece al reiniciar.",
+        ["undervolt_cpu"] = "CPU",
+        ["undervolt_auto_apply"] = "Aplicar automáticamente al cambiar de modo",
+
         // BATTERY INFO WINDOW
         ["battery_info_title"] = "Información de la batería",
         ["health_header"] = "Salud",

--- a/src/I18n/Languages/Swedish.cs
+++ b/src/I18n/Languages/Swedish.cs
@@ -307,6 +307,12 @@ public static class Swedish
         ["firmware_control"] = "Firmware-styrning",
         ["fan_sensor_format"] = "CPU: {0} / GPU: {1} Last: {2}   Mitt: {3} RPM",
 
+        // UNDERVOLTING
+        ["undervolt_header"] = "Undervolting (experimentellt)",
+        ["undervolt_desc"] = "Curve Optimizer-förskjutning. Mer negativ = lägre spänning. För låga värden kan orsaka instabilitet eller datakorruption. Börja smått. Återställs vid omstart.",
+        ["undervolt_cpu"] = "CPU",
+        ["undervolt_auto_apply"] = "Tillämpa automatiskt vid lägesändring",
+
         // BATTERY INFO WINDOW
         ["battery_info_title"] = "Batteriinformation",
         ["health_header"] = "Hälsa",

--- a/src/I18n/Languages/Thai.cs
+++ b/src/I18n/Languages/Thai.cs
@@ -307,6 +307,12 @@ public static class Thai
         ["firmware_control"] = "ควบคุมเฟิร์มแวร์",
         ["fan_sensor_format"] = "CPU: {0} / GPU: {1} โหลด: {2}   กลาง: {3} RPM",
 
+        // UNDERVOLTING
+        ["undervolt_header"] = "Undervolting (ทดลอง)",
+        ["undervolt_desc"] = "ออฟเซ็ต Curve Optimizer ค่ายิ่งลบ = แรงดันยิ่งต่ำ ค่าที่ต่ำเกินไปอาจทำให้ระบบไม่เสถียรหรือข้อมูลเสียหาย เริ่มจากค่าน้อยก่อน รีเซ็ตเมื่อรีบูต",
+        ["undervolt_cpu"] = "CPU",
+        ["undervolt_auto_apply"] = "ใช้อัตโนมัติเมื่อเปลี่ยนโหมด",
+
         // BATTERY INFO WINDOW
         ["battery_info_title"] = "ข้อมูลแบตเตอรี่",
         ["health_header"] = "สุขภาพ",

--- a/src/I18n/Languages/Turkish.cs
+++ b/src/I18n/Languages/Turkish.cs
@@ -304,6 +304,12 @@ public static class Turkish
         ["firmware_control"] = "Firmware kontrolü",
         ["fan_sensor_format"] = "CPU: {0} / GPU: {1} Yük: {2}   Orta: {3} RPM",
 
+        // UNDERVOLTING
+        ["undervolt_header"] = "Undervolting (Deneysel)",
+        ["undervolt_desc"] = "Curve Optimizer ofseti. Daha negatif = daha düşük voltaj. Çok düşük değerler kararsızlığa veya veri bozulmasına yol açabilir. Küçük başlayın. Yeniden başlatmada sıfırlanır.",
+        ["undervolt_cpu"] = "CPU",
+        ["undervolt_auto_apply"] = "Mod değişiminde otomatik uygula",
+
         // BATTERY INFO WINDOW
         ["battery_info_title"] = "Batarya Bilgisi",
         ["health_header"] = "Sağlık",

--- a/src/I18n/Languages/Ukrainian.cs
+++ b/src/I18n/Languages/Ukrainian.cs
@@ -304,6 +304,12 @@ public static class Ukrainian
         ["firmware_control"] = "Контроль прошивки",
         ["fan_sensor_format"] = "CPU: {0} / GPU: {1} Навант.: {2}   Серед.: {3} RPM",
 
+        // UNDERVOLTING
+        ["undervolt_header"] = "Андервольтинг (експериментально)",
+        ["undervolt_desc"] = "Зсув Curve Optimizer. Більш від'ємне = нижча напруга. Надто низькі значення можуть спричинити нестабільність або пошкодження даних. Починайте з малого. Скидається при перезавантаженні.",
+        ["undervolt_cpu"] = "CPU",
+        ["undervolt_auto_apply"] = "Автоматично застосовувати при зміні режиму",
+
         // BATTERY INFO WINDOW
         ["battery_info_title"] = "Інформація про батарею",
         ["health_header"] = "Здоров'я",

--- a/src/I18n/Languages/Vietnamese.cs
+++ b/src/I18n/Languages/Vietnamese.cs
@@ -304,6 +304,12 @@ public static class Vietnamese
         ["firmware_control"] = "Điều khiển firmware",
         ["fan_sensor_format"] = "CPU: {0} / GPU: {1} Tải: {2}   Giữa: {3} RPM",
 
+        // UNDERVOLTING
+        ["undervolt_header"] = "Undervolting (thử nghiệm)",
+        ["undervolt_desc"] = "Offset Curve Optimizer. Càng âm = điện áp càng thấp. Giá trị quá thấp có thể gây mất ổn định hoặc hỏng dữ liệu. Bắt đầu từ nhỏ. Đặt lại khi khởi động lại.",
+        ["undervolt_cpu"] = "CPU",
+        ["undervolt_auto_apply"] = "Tự động áp dụng khi đổi chế độ",
+
         // BATTERY INFO WINDOW
         ["battery_info_title"] = "Thông tin pin",
         ["health_header"] = "Tình trạng",

--- a/src/Mode/ModeControl.cs
+++ b/src/Mode/ModeControl.cs
@@ -162,6 +162,9 @@ public class ModeControl
 
             AutoPower(mode);
 
+            // Ryzen CO undervolt (independent of auto_apply_power — uses its own auto_uv flag)
+            AutoRyzen();
+
             // CPU Boost override
             int autoBoost = Helpers.AppConfig.GetMode("auto_boost");
             if (autoBoost >= 0)
@@ -324,6 +327,35 @@ public class ModeControl
 
         // Verify PPT writes took effect - read back and warn on mismatches
         VerifyPptLimits(wmi, pl1, pl2, fppt, apuPlatCeiling > 0 ? apuPlatCeiling : -1);
+    }
+
+    // ── Ryzen Curve Optimizer undervolt (mirrors Windows ModeControl.AutoRyzen/SetRyzen/ResetRyzen/SetUV) ──
+
+    /// <summary>Apply or reset CPU undervolt for the current mode, based on "auto_uv" flag.</summary>
+    public void AutoRyzen()
+    {
+        if (App.Smu == null || !App.Smu.IsAvailable) return;
+        if (Helpers.AppConfig.IsMode("auto_uv")) SetRyzen();
+        else ResetRyzen();
+    }
+
+    /// <summary>Apply the current mode's saved cpu_uv value to the SMU.</summary>
+    public void SetRyzen()
+    {
+        int cpuUV = Helpers.AppConfig.GetMode("cpu_uv", 0);
+        SetUV(cpuUV);
+    }
+
+    /// <summary>Reset CPU undervolt to 0 (stock voltage).</summary>
+    public void ResetRyzen() => SetUV(0);
+
+    private static void SetUV(int cpuUV)
+    {
+        cpuUV = Math.Clamp(cpuUV, Platform.Linux.RyzenSmu.MinCPUUV, Platform.Linux.RyzenSmu.MaxCPUUV);
+        if (App.Smu?.SetCoAll(cpuUV) == true)
+            Helpers.Logger.WriteLine($"Ryzen UV: cpu_uv={cpuUV} applied");
+        else
+            Helpers.Logger.WriteLine($"Ryzen UV: cpu_uv={cpuUV} apply FAILED");
     }
 
     /// <summary>

--- a/src/Mode/ModeControl.cs
+++ b/src/Mode/ModeControl.cs
@@ -329,14 +329,17 @@ public class ModeControl
         VerifyPptLimits(wmi, pl1, pl2, fppt, apuPlatCeiling > 0 ? apuPlatCeiling : -1);
     }
 
-    // ── Ryzen Curve Optimizer undervolt (mirrors Windows ModeControl.AutoRyzen/SetRyzen/ResetRyzen/SetUV) ──
+    // Ryzen Curve Optimizer undervolt (mirrors Windows ModeControl.AutoRyzen/SetRyzen/ResetRyzen/SetUV)
 
     /// <summary>Apply or reset CPU undervolt for the current mode, based on "auto_uv" flag.</summary>
     public void AutoRyzen()
     {
-        if (App.Smu == null || !App.Smu.IsAvailable) return;
-        if (Helpers.AppConfig.IsMode("auto_uv")) SetRyzen();
-        else ResetRyzen();
+        if (App.Smu == null || !App.Smu.IsAvailable)
+            return;
+        if (Helpers.AppConfig.IsMode("auto_uv"))
+            SetRyzen();
+        else
+            ResetRyzen();
     }
 
     /// <summary>Apply the current mode's saved cpu_uv value to the SMU.</summary>

--- a/src/Platform/Linux/RyzenSmu.cs
+++ b/src/Platform/Linux/RyzenSmu.cs
@@ -1,0 +1,478 @@
+namespace GHelper.Linux.Platform.Linux;
+
+/// <summary>
+/// Interface to the ryzen_smu kernel driver for Curve Optimizer (CO) undervolting.
+///
+/// Public API mirrors the Windows g-helper PawnIO.RyzenSmuService: SetCoAll / ResetCoAll,
+/// plus IsAvailable (analogous to CanSetCoAll / IsInitialized). The backend is different
+/// (ryzen_smu sysfs vs. PawnIO), but the SMU protocol and CO semantics are the same.
+///
+/// CO works via SMU mailbox commands (NOT x86 MSRs):
+///   Userspace → ryzen_smu sysfs → PCI config → SMN bus → SMU mailbox → SMU firmware
+///
+/// The ryzen_smu driver exposes:
+///   /sys/kernel/ryzen_smu_drv/rsmu_cmd   — write: trigger RSMU command (blocks until done)
+///                                           read: response status (0x01 = OK)
+///   /sys/kernel/ryzen_smu_drv/smu_args   — write: set 6x uint32 LE arguments (24 bytes)
+///                                           read: response arguments after command
+///   /sys/kernel/ryzen_smu_drv/codename   — CPU codename ID from driver
+///
+/// Protocol (from ryzen_smu drv.c, mutex-serialized in kernel):
+///   1. Write 24 bytes to smu_args
+///   2. Write 4 bytes to rsmu_cmd — triggers command, blocks until SMU responds
+///   3. Read 4 bytes from rsmu_cmd — response status
+///   4. Read 24 bytes from smu_args — response data
+///
+/// Command IDs verified from ZenStates-Core (irusanov/ZenStates-Core):
+///   Zen4Settings.cs + DragonRangeSettings.cs (identical RSMU CO commands)
+///
+/// CO values are NOT persistent — they reset on every reboot.
+///
+/// SAFETY:
+///   - Startup validation: sends a read-only GetDldoPsmMargin before allowing writes
+///   - Range clamped to [MinCPUUV, MaxCPUUV] (matches Windows CpuInfo.MinCPUUV/MaxCPUUV)
+///   - Read-back verification after every write
+///   - All SMU interactions logged
+///   - Application-level lock (defense-in-depth over kernel mutex)
+/// </summary>
+public sealed class RyzenSmu : IDisposable
+{
+    private const string DriverPath = "/sys/kernel/ryzen_smu_drv";
+    private const string RsmuCmdPath = DriverPath + "/rsmu_cmd";
+    private const string SmuArgsPath = DriverPath + "/smu_args";
+    private const string CodenamePath = DriverPath + "/codename";
+    private const string VersionPath = DriverPath + "/version";
+
+    // SMU response codes (from ryzen_smu smu.h)
+    private const uint SMU_RETURN_OK = 0x01;
+    private const uint SMU_RETURN_FAILED = 0xFF;
+    private const uint SMU_RETURN_UNKNOWN_CMD = 0xFE;
+    private const uint SMU_RETURN_CMD_REJECTED_PREREQ = 0xFD;
+    private const uint SMU_RETURN_CMD_REJECTED_BUSY = 0xFC;
+
+    // UV bounds matching Windows PawnIO.CpuInfo.MinCPUUV / MaxCPUUV.
+    // BIOS Curve Optimizer range is [-30, +30] but Windows uses [-40, 0]; SMU firmware
+    // will reject or clamp values beyond what the silicon accepts.
+    public const int MinCPUUV = -40;
+    public const int MaxCPUUV = 0;
+
+    /// <summary>
+    /// RSMU command IDs for Curve Optimizer, per CPU generation.
+    /// Verified from ZenStates-Core source (Zen3Settings.cs, Zen4Settings.cs, DragonRangeSettings.cs).
+    /// </summary>
+    private record SmuCommandSet(
+        uint SetAllCoreCO,    // SetAllDldoPsmMargin
+        uint SetPerCoreCO,    // SetDldoPsmMargin
+        uint GetPerCoreCO     // GetDldoPsmMargin (read-only, used for validation)
+    );
+
+    // ryzen_smu codename IDs (from amkillam/ryzen_smu smu.h enum smu_processor_codename)
+    // Verified: codename 20 = CODENAME_RAPHAEL (covers Dragon Range mobile too)
+    private const int CODENAME_VERMEER = 12;       // Zen 3 desktop (5000 series)        — untested
+    private const int CODENAME_CEZANNE = 14;       // Zen 3 APU (5000G series)           — untested
+    private const int CODENAME_RAPHAEL = 20;       // Zen 4 desktop + Dragon Range mobile — TESTED on AMD Ryzen 9 7845HX
+    private const int CODENAME_PHOENIX = 21;       // Zen 4 APU (7040 series)            — untested
+    private const int CODENAME_GRANITE_RIDGE = 23; // Zen 5 desktop (9000 series)        — untested
+
+    // Only codenames in this dictionary are enabled. Uncomment an entry to enable a CPU
+    // generation after it has been verified on real hardware.
+    private static readonly Dictionary<int, SmuCommandSet> CommandSets = new()
+    {
+        // Zen 3 RSMU — ZenStates-Core/SMUSettings/Zen3Settings.cs
+        // [CODENAME_VERMEER] = new(SetAllCoreCO: 0x0B, SetPerCoreCO: 0x0A, GetPerCoreCO: 0x7C),
+        // [CODENAME_CEZANNE] = new(SetAllCoreCO: 0x0B, SetPerCoreCO: 0x0A, GetPerCoreCO: 0x7C),
+
+        // Zen 4 RSMU — ZenStates-Core/SMUSettings/Zen4Settings.cs + DragonRangeSettings.cs (identical)
+        [CODENAME_RAPHAEL] = new(SetAllCoreCO: 0x07, SetPerCoreCO: 0x06, GetPerCoreCO: 0xD5),
+        // [CODENAME_PHOENIX] = new(SetAllCoreCO: 0x07, SetPerCoreCO: 0x06, GetPerCoreCO: 0xD5),
+
+        // Zen 5 RSMU — ZenStates-Core/SMUSettings/Zen5Settings.cs
+        // [CODENAME_GRANITE_RIDGE] = new(SetAllCoreCO: 0x07, SetPerCoreCO: 0x06, GetPerCoreCO: 0xD5),
+    };
+
+    private SmuCommandSet? _commands;
+    private int _codename = -1;
+    private readonly object _smuLock = new();  // Defense-in-depth over kernel mutex
+
+    /// <summary>Whether the driver is present, the CPU is supported, and validation passed.</summary>
+    public bool IsAvailable { get; private set; }
+
+    /// <summary>Human-readable reason if IsAvailable is false.</summary>
+    public string? UnavailableReason { get; private set; }
+
+    /// <summary>ryzen_smu codename ID.</summary>
+    public int Codename => _codename;
+
+    public RyzenSmu()
+    {
+        try
+        {
+            if (!Directory.Exists(DriverPath))
+            {
+                UnavailableReason = "ryzen_smu driver not loaded";
+                Helpers.Logger.WriteLine("RyzenSmu: " + UnavailableReason);
+                return;
+            }
+
+            // Check write permissions on command files
+            if (!IsWritable(RsmuCmdPath) || !IsWritable(SmuArgsPath))
+            {
+                UnavailableReason = "no write permission on ryzen_smu files (need root or udev rule)";
+                Helpers.Logger.WriteLine("RyzenSmu: " + UnavailableReason);
+                return;
+            }
+
+            var codenameStr = SysfsHelper.ReadAttribute(CodenamePath);
+            if (codenameStr == null || !int.TryParse(codenameStr, out _codename))
+            {
+                UnavailableReason = "could not read CPU codename from driver";
+                Helpers.Logger.WriteLine("RyzenSmu: " + UnavailableReason);
+                return;
+            }
+
+            if (!CommandSets.TryGetValue(_codename, out _commands))
+            {
+                UnavailableReason = $"unsupported CPU codename {_codename}";
+                Helpers.Logger.WriteLine("RyzenSmu: " + UnavailableReason);
+                return;
+            }
+
+            var version = SysfsHelper.ReadAttribute(VersionPath);
+            string codenameLabel = _codename switch
+            {
+                CODENAME_VERMEER => "Vermeer (Zen 3)",
+                CODENAME_CEZANNE => "Cezanne (Zen 3 APU)",
+                CODENAME_RAPHAEL => "Raphael/DragonRange (Zen 4)",
+                CODENAME_PHOENIX => "Phoenix (Zen 4 APU)",
+                CODENAME_GRANITE_RIDGE => "Granite Ridge (Zen 5)",
+                _ => $"unknown ({_codename})"
+            };
+            Helpers.Logger.WriteLine($"RyzenSmu: codename={_codename} ({codenameLabel}), SMU firmware={version}");
+
+            // Validate: send a read-only GetDldoPsmMargin for CCD0/core0.
+            // If the SMU rejects this with "unknown command", the command set is wrong
+            // and we must NOT attempt any writes.
+            if (!ValidateCommandSet())
+            {
+                UnavailableReason = "SMU command validation failed — CO commands not accepted by firmware";
+                Helpers.Logger.WriteLine("RyzenSmu: " + UnavailableReason);
+                _commands = null; // Prevent any further use
+                return;
+            }
+
+            Helpers.Logger.WriteLine("RyzenSmu: validation passed, Curve Optimizer available");
+            IsAvailable = true;
+        }
+        catch (Exception ex)
+        {
+            UnavailableReason = $"initialization error: {ex.Message}";
+            Helpers.Logger.WriteLine("RyzenSmu: init failed", ex);
+        }
+    }
+
+    /// <summary>
+    /// Validate the command set by sending a read-only GetDldoPsmMargin.
+    /// This is non-destructive — it only reads the current CO value for CCD0/core0.
+    /// Returns true if the SMU accepted the command (status = OK).
+    /// </summary>
+    private bool ValidateCommandSet()
+    {
+        if (_commands == null) return false;
+
+        Helpers.Logger.WriteLine("RyzenSmu: validating with GetDldoPsmMargin (read-only) for CCD0/core0...");
+
+        // CCD0, core0 mask
+        uint coreMask = 0; // (0 << 28) | (0 << 20) = 0
+
+        var (status, _) = SendRsmuCommandRaw(_commands.GetPerCoreCO, coreMask);
+
+        if (status == SMU_RETURN_OK)
+        {
+            Helpers.Logger.WriteLine("RyzenSmu: validation OK — GetDldoPsmMargin accepted");
+            return true;
+        }
+        else if (status == SMU_RETURN_UNKNOWN_CMD)
+        {
+            Helpers.Logger.WriteLine($"RyzenSmu: VALIDATION FAILED — SMU returned 'unknown command' (0x{status:X2}). " +
+                "Command IDs may not match this firmware version. Disabling CO to prevent damage.");
+            return false;
+        }
+        else
+        {
+            Helpers.Logger.WriteLine($"RyzenSmu: validation returned unexpected status 0x{status:X2}. " +
+                "Disabling CO as a safety precaution.");
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Set Curve Optimizer offset for ALL cores. Mirrors Windows RyzenSmuService.SetCoAll.
+    /// </summary>
+    /// <param name="offset">CO offset, clamped to [MinCPUUV, MaxCPUUV]. Negative = undervolt.</param>
+    /// <returns>True if the SMU accepted the command. Read-back is logged; a mismatch
+    /// does NOT flip the return to false (the write itself still succeeded).</returns>
+    public bool SetCoAll(int offset)
+    {
+        if (!IsAvailable || _commands == null) return false;
+
+        offset = Math.Clamp(offset, MinCPUUV, MaxCPUUV);
+        uint encoded = EncodeCOMargin(offset);
+
+        Helpers.Logger.WriteLine($"RyzenSmu: SetCoAll offset={offset} encoded=0x{encoded:X4}");
+
+        bool ok = SendRsmuCommand(_commands.SetAllCoreCO, encoded);
+        if (!ok)
+        {
+            Helpers.Logger.WriteLine("RyzenSmu: SetCoAll FAILED");
+            return false;
+        }
+
+        // Read-back verification: check core 0 to confirm the value took effect
+        int? readback = GetPerCoreCO(0, 0);
+        if (readback != null)
+        {
+            Helpers.Logger.WriteLine($"RyzenSmu: SetCoAll readback CCD0/core0 = {readback}");
+            if (readback != offset)
+                Helpers.Logger.WriteLine($"RyzenSmu: WARNING — readback ({readback}) differs from requested ({offset})");
+        }
+        else
+        {
+            Helpers.Logger.WriteLine("RyzenSmu: SetCoAll readback failed (write may still have succeeded)");
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Set Curve Optimizer offset for a single core. Kept for future per-core UI
+    /// (no Windows public analogue; internal helper).
+    /// </summary>
+    /// <param name="ccd">CCD index (0-based)</param>
+    /// <param name="core">Core index within CCD (0-7)</param>
+    /// <param name="offset">CO offset, clamped to [MinCPUUV, MaxCPUUV]. Negative = undervolt.</param>
+    public bool SetPerCoreCO(int ccd, int core, int offset)
+    {
+        if (!IsAvailable || _commands == null) return false;
+
+        offset = Math.Clamp(offset, MinCPUUV, MaxCPUUV);
+        uint encoded = EncodeCOMargin(offset);
+
+        // Bit layout (verified from ZenStates-Core Cpu.cs MakeCoreMask for Family > 17h):
+        //   [31:28] = CCD index
+        //   [23:20] = core index within CCD (mod 8)
+        //   [15:0]  = CO margin (16-bit two's complement)
+        uint coreMask = ((uint)ccd << 28) | ((uint)(core % 8) << 20);
+        uint arg = (coreMask & 0xFFF00000) | encoded;
+
+        Helpers.Logger.WriteLine($"RyzenSmu: SetPerCoreCO ccd={ccd} core={core} offset={offset} arg=0x{arg:X8}");
+
+        bool ok = SendRsmuCommand(_commands.SetPerCoreCO, arg);
+        if (!ok)
+        {
+            Helpers.Logger.WriteLine($"RyzenSmu: SetPerCoreCO ccd={ccd} core={core} FAILED");
+            return false;
+        }
+
+        // Read-back verification
+        int? readback = GetPerCoreCO(ccd, core);
+        if (readback != null)
+        {
+            Helpers.Logger.WriteLine($"RyzenSmu: SetPerCoreCO readback CCD{ccd}/core{core} = {readback}");
+            if (readback != offset)
+                Helpers.Logger.WriteLine($"RyzenSmu: WARNING — readback ({readback}) differs from requested ({offset})");
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Read the current CO offset for a single core (non-destructive).
+    /// </summary>
+    /// <returns>The CO offset value, or null on failure.</returns>
+    public int? GetPerCoreCO(int ccd, int core)
+    {
+        if (!IsAvailable || _commands == null) return null;
+
+        uint coreMask = ((uint)ccd << 28) | ((uint)(core % 8) << 20);
+
+        var (status, results) = SendRsmuCommandRaw(_commands.GetPerCoreCO, coreMask);
+        if (status != SMU_RETURN_OK || results == null)
+            return null;
+
+        // Decode args[0] as a 16-bit two's complement value (matches write encoding).
+        // SMU firmware fills only the low 16 bits with the CO margin; upper bits are
+        // not guaranteed to be sign-extended, so a raw cast to int32 would turn -22
+        // (0xFFEA) into 65514. Sign-extend via a short cast.
+        short margin = (short)(results[0] & 0xFFFF);
+        return margin;
+    }
+
+    /// <summary>
+    /// Reset CO for all cores to 0 (no offset). Mirrors Windows convention of calling
+    /// SetCoAll(0) through ModeControl.ResetRyzen.
+    /// </summary>
+    public bool ResetCoAll()
+    {
+        Helpers.Logger.WriteLine("RyzenSmu: resetting all-core CO to 0");
+        return SetCoAll(0);
+    }
+
+    /// <summary>
+    /// Encode a CO margin for the SMU.
+    /// Verified from ZenStates-Core Utils.cs MakePsmMarginArg:
+    ///   Negative: 16-bit two's complement (e.g., -22 → 0xFFEA)
+    ///   Positive: raw value (e.g., +5 → 0x0005)
+    /// </summary>
+    private static uint EncodeCOMargin(int margin)
+    {
+        if (margin < 0)
+            return (uint)((0x100000 + margin) & 0xFFFF);
+        return (uint)(margin & 0xFFFF);
+    }
+
+    /// <summary>
+    /// Send an RSMU command, returning only success/failure.
+    /// </summary>
+    private bool SendRsmuCommand(uint command, uint arg0)
+    {
+        var (status, _) = SendRsmuCommandRaw(command, arg0);
+        return status == SMU_RETURN_OK;
+    }
+
+    /// <summary>
+    /// Send an RSMU command and return the raw status + response arguments.
+    /// Thread-safe via application-level lock (kernel also serializes internally).
+    ///
+    /// Protocol (verified from ryzen_smu drv.c):
+    ///   1. Write 24 bytes to smu_args (6x uint32 LE)
+    ///   2. Write 4 bytes to rsmu_cmd (triggers command, blocks until SMU responds)
+    ///   3. Read 4 bytes from rsmu_cmd (response status)
+    ///   4. Read 24 bytes from smu_args (response data)
+    /// </summary>
+    private (uint status, uint[]? results) SendRsmuCommandRaw(uint command, uint arg0)
+    {
+        lock (_smuLock)
+        {
+            try
+            {
+                // Step 1: Write arguments (6x uint32 = 24 bytes, little-endian)
+                var argsBytes = new byte[24];
+                BitConverter.TryWriteBytes(argsBytes.AsSpan(0, 4), arg0);
+                // args[1..5] remain 0
+
+                File.WriteAllBytes(SmuArgsPath, argsBytes);
+
+                // Step 2: Write command (triggers SMU execution, blocks)
+                var cmdBytes = new byte[4];
+                BitConverter.TryWriteBytes(cmdBytes.AsSpan(0, 4), command);
+                File.WriteAllBytes(RsmuCmdPath, cmdBytes);
+
+                // Step 3: Read response status.
+                // sysfs files report st_size=4096 but only yield 4 actual bytes,
+                // so File.ReadAllBytes (which trusts stream length) throws
+                // "Unable to read beyond the end of the stream". Use fixed-size
+                // buffer reads instead.
+                var respBytes = ReadSysfsBytes(RsmuCmdPath, 4);
+                if (respBytes.Length < 4)
+                {
+                    Helpers.Logger.WriteLine($"RyzenSmu: short response from rsmu_cmd ({respBytes.Length} bytes)");
+                    return (0, null);
+                }
+
+                uint status = BitConverter.ToUInt32(respBytes, 0);
+
+                if (status != SMU_RETURN_OK)
+                {
+                    string statusName = status switch
+                    {
+                        SMU_RETURN_FAILED => "FAILED",
+                        SMU_RETURN_UNKNOWN_CMD => "UNKNOWN_CMD",
+                        SMU_RETURN_CMD_REJECTED_PREREQ => "REJECTED_PREREQ",
+                        SMU_RETURN_CMD_REJECTED_BUSY => "REJECTED_BUSY",
+                        _ => $"0x{status:X2}"
+                    };
+                    Helpers.Logger.WriteLine($"RyzenSmu: command 0x{command:X2} returned {statusName}");
+                    return (status, null);
+                }
+
+                // Step 4: Read response arguments
+                var resultBytes = ReadSysfsBytes(SmuArgsPath, 24);
+                uint[]? results = null;
+                if (resultBytes.Length >= 24)
+                {
+                    results = new uint[6];
+                    for (int i = 0; i < 6; i++)
+                        results[i] = BitConverter.ToUInt32(resultBytes, i * 4);
+                }
+
+                return (status, results);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                Helpers.Logger.WriteLine($"RyzenSmu: permission denied for command 0x{command:X2} — need root or udev rule", ex);
+                return (0, null);
+            }
+            catch (Exception ex)
+            {
+                Helpers.Logger.WriteLine($"RyzenSmu: command 0x{command:X2} exception", ex);
+                return (0, null);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Read exactly <paramref name="count"/> bytes from a sysfs pseudo-file.
+    /// sysfs files report st_size=4096 but contain far fewer bytes, so
+    /// File.ReadAllBytes (which pre-allocates based on stream length) fails with
+    /// "Unable to read beyond the end of the stream". This method opens the file
+    /// and reads up to <paramref name="count"/> bytes without trusting the reported size.
+    /// </summary>
+    private static byte[] ReadSysfsBytes(string path, int count)
+    {
+        var buf = new byte[count];
+        using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        int total = 0;
+        while (total < count)
+        {
+            int n = fs.Read(buf, total, count - total);
+            if (n == 0) break;
+            total += n;
+        }
+        if (total == count) return buf;
+        var trimmed = new byte[total];
+        Array.Copy(buf, trimmed, total);
+        return trimmed;
+    }
+
+    /// <summary>Check if a sysfs file is writable by the current user.</summary>
+    private static bool IsWritable(string path)
+    {
+        try
+        {
+            if (!File.Exists(path)) return false;
+            using var fs = File.Open(path, FileMode.Open, FileAccess.Write, FileShare.ReadWrite);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>Format an SMU status code for display.</summary>
+    public static string FormatStatus(uint status) => status switch
+    {
+        SMU_RETURN_OK => "OK",
+        SMU_RETURN_FAILED => "Failed",
+        SMU_RETURN_UNKNOWN_CMD => "Unknown command",
+        SMU_RETURN_CMD_REJECTED_PREREQ => "Rejected (prerequisite)",
+        SMU_RETURN_CMD_REJECTED_BUSY => "Rejected (busy)",
+        _ => $"Unknown (0x{status:X2})"
+    };
+
+    public void Dispose()
+    {
+        // No persistent resources to clean up.
+        // CO values persist until reboot (SMU firmware state), not tied to this object.
+    }
+}

--- a/src/Platform/Linux/RyzenSmu.cs
+++ b/src/Platform/Linux/RyzenSmu.cs
@@ -35,7 +35,7 @@ namespace GHelper.Linux.Platform.Linux;
 ///   - All SMU interactions logged
 ///   - Application-level lock (defense-in-depth over kernel mutex)
 /// </summary>
-public sealed class RyzenSmu : IDisposable
+public sealed class RyzenSmu
 {
     private const string DriverPath = "/sys/kernel/ryzen_smu_drv";
     private const string RsmuCmdPath = DriverPath + "/rsmu_cmd";
@@ -177,7 +177,8 @@ public sealed class RyzenSmu : IDisposable
     /// </summary>
     private bool ValidateCommandSet()
     {
-        if (_commands == null) return false;
+        if (_commands == null)
+            return false;
 
         Helpers.Logger.WriteLine("RyzenSmu: validating with GetDldoPsmMargin (read-only) for CCD0/core0...");
 
@@ -213,7 +214,8 @@ public sealed class RyzenSmu : IDisposable
     /// does NOT flip the return to false (the write itself still succeeded).</returns>
     public bool SetCoAll(int offset)
     {
-        if (!IsAvailable || _commands == null) return false;
+        if (!IsAvailable || _commands == null)
+            return false;
 
         offset = Math.Clamp(offset, MinCPUUV, MaxCPUUV);
         uint encoded = EncodeCOMargin(offset);
@@ -252,7 +254,8 @@ public sealed class RyzenSmu : IDisposable
     /// <param name="offset">CO offset, clamped to [MinCPUUV, MaxCPUUV]. Negative = undervolt.</param>
     public bool SetPerCoreCO(int ccd, int core, int offset)
     {
-        if (!IsAvailable || _commands == null) return false;
+        if (!IsAvailable || _commands == null)
+            return false;
 
         offset = Math.Clamp(offset, MinCPUUV, MaxCPUUV);
         uint encoded = EncodeCOMargin(offset);
@@ -291,7 +294,8 @@ public sealed class RyzenSmu : IDisposable
     /// <returns>The CO offset value, or null on failure.</returns>
     public int? GetPerCoreCO(int ccd, int core)
     {
-        if (!IsAvailable || _commands == null) return null;
+        if (!IsAvailable || _commands == null)
+            return null;
 
         uint coreMask = ((uint)ccd << 28) | ((uint)(core % 8) << 20);
 
@@ -435,10 +439,12 @@ public sealed class RyzenSmu : IDisposable
         while (total < count)
         {
             int n = fs.Read(buf, total, count - total);
-            if (n == 0) break;
+            if (n == 0)
+                break;
             total += n;
         }
-        if (total == count) return buf;
+        if (total == count)
+            return buf;
         var trimmed = new byte[total];
         Array.Copy(buf, trimmed, total);
         return trimmed;
@@ -449,7 +455,8 @@ public sealed class RyzenSmu : IDisposable
     {
         try
         {
-            if (!File.Exists(path)) return false;
+            if (!File.Exists(path))
+                return false;
             using var fs = File.Open(path, FileMode.Open, FileAccess.Write, FileShare.ReadWrite);
             return true;
         }
@@ -470,9 +477,4 @@ public sealed class RyzenSmu : IDisposable
         _ => $"Unknown (0x{status:X2})"
     };
 
-    public void Dispose()
-    {
-        // No persistent resources to clean up.
-        // CO values persist until reboot (SMU firmware state), not tied to this object.
-    }
 }

--- a/src/UI/Views/FansWindow.axaml
+++ b/src/UI/Views/FansWindow.axaml
@@ -129,15 +129,15 @@
             </StackPanel>
         </Border>
 
-        <!-- ═══════════════════ UNDERVOLTING (Ryzen CO) ═══════════════════ -->
+        <!-- Undervolting (Ryzen CO) -->
         <Border Grid.Row="3" x:Name="panelUV" Classes="panel" Margin="10,0,10,10" IsVisible="False">
             <StackPanel>
-                <TextBlock Classes="header" Text="Undervolting (Experimental)" Margin="0,0,0,4" />
-                <TextBlock Classes="label-dim" TextWrapping="Wrap" Margin="0,0,0,8"
+                <TextBlock x:Name="headerUndervolt" Classes="header" Text="Undervolting (Experimental)" Margin="0,0,0,4" />
+                <TextBlock x:Name="labelUndervoltDesc" Classes="label-dim" TextWrapping="Wrap" Margin="0,0,0,8"
                            Text="Curve Optimizer offset. More negative = lower voltage. Too-low values can cause instability or data corruption. Start small. Resets on reboot." />
 
                 <Grid ColumnDefinitions="120,*,50" Margin="0,4">
-                    <TextBlock Grid.Column="0" Text="CPU"
+                    <TextBlock Grid.Column="0" x:Name="labelUndervoltCpu" Text="CPU"
                                Classes="label-dim" VerticalAlignment="Center" />
                     <!-- Slider is positive 0..40 (intensity) so the fill bar grows
                          left-to-right with UV strength; value is negated when stored. -->
@@ -158,8 +158,7 @@
                     <CheckBox x:Name="checkApplyUV"
                               Content="Auto-apply on mode change"
                               VerticalAlignment="Center"
-                              Checked="CheckApplyUV_Changed"
-                              Unchecked="CheckApplyUV_Changed" />
+                              IsCheckedChanged="CheckApplyUV_Changed" />
                 </StackPanel>
             </StackPanel>
         </Border>

--- a/src/UI/Views/FansWindow.axaml
+++ b/src/UI/Views/FansWindow.axaml
@@ -11,7 +11,7 @@
         Background="#1C1C1C"
         Icon="avares://ghelper/UI/Assets/standard.ico">
 
-    <Grid RowDefinitions="Auto,*,Auto">
+    <Grid RowDefinitions="Auto,*,Auto,Auto">
 
         <!-- HEADER -->
         <Border Grid.Row="0" Classes="panel-header" Margin="10,10,10,5">
@@ -126,6 +126,39 @@
                 <!-- Sensor readings -->
                 <TextBlock x:Name="labelSensors" Classes="label-dim"
                            Text="" Margin="0,8,0,0" />
+            </StackPanel>
+        </Border>
+
+        <!-- ═══════════════════ UNDERVOLTING (Ryzen CO) ═══════════════════ -->
+        <Border Grid.Row="3" x:Name="panelUV" Classes="panel" Margin="10,0,10,10" IsVisible="False">
+            <StackPanel>
+                <TextBlock Classes="header" Text="Undervolting (Experimental)" Margin="0,0,0,4" />
+                <TextBlock Classes="label-dim" TextWrapping="Wrap" Margin="0,0,0,8"
+                           Text="Curve Optimizer offset. More negative = lower voltage. Too-low values can cause instability or data corruption. Start small. Resets on reboot." />
+
+                <Grid ColumnDefinitions="120,*,50" Margin="0,4">
+                    <TextBlock Grid.Column="0" Text="CPU"
+                               Classes="label-dim" VerticalAlignment="Center" />
+                    <Slider Grid.Column="1" x:Name="sliderCpuUV"
+                            Minimum="-40" Maximum="0" Value="0"
+                            TickFrequency="1" IsSnapToTickEnabled="True"
+                            ValueChanged="SliderCpuUV_ValueChanged" />
+                    <TextBlock Grid.Column="2" x:Name="labelCpuUV" Classes="value"
+                               Text="0" HorizontalAlignment="Center"
+                               VerticalAlignment="Center" />
+                </Grid>
+
+                <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,8,0,0">
+                    <Button x:Name="buttonApplyUV" Classes="ghelper"
+                            Content="Apply" Click="ButtonApplyUV_Click" />
+                    <Button x:Name="buttonResetUV" Classes="ghelper"
+                            Content="Reset" Click="ButtonResetUV_Click" />
+                    <CheckBox x:Name="checkApplyUV"
+                              Content="Auto-apply on mode change"
+                              VerticalAlignment="Center"
+                              Checked="CheckApplyUV_Changed"
+                              Unchecked="CheckApplyUV_Changed" />
+                </StackPanel>
             </StackPanel>
         </Border>
 

--- a/src/UI/Views/FansWindow.axaml
+++ b/src/UI/Views/FansWindow.axaml
@@ -139,8 +139,10 @@
                 <Grid ColumnDefinitions="120,*,50" Margin="0,4">
                     <TextBlock Grid.Column="0" Text="CPU"
                                Classes="label-dim" VerticalAlignment="Center" />
+                    <!-- Slider is positive 0..40 (intensity) so the fill bar grows
+                         left-to-right with UV strength; value is negated when stored. -->
                     <Slider Grid.Column="1" x:Name="sliderCpuUV"
-                            Minimum="-40" Maximum="0" Value="0"
+                            Minimum="0" Maximum="40" Value="0"
                             TickFrequency="1" IsSnapToTickEnabled="True"
                             ValueChanged="SliderCpuUV_ValueChanged" />
                     <TextBlock Grid.Column="2" x:Name="labelCpuUV" Classes="value"

--- a/src/UI/Views/FansWindow.axaml.cs
+++ b/src/UI/Views/FansWindow.axaml.cs
@@ -70,6 +70,12 @@ public partial class FansWindow : Window
         chartCPU.FanLabel = Labels.Get("cpu_fan");
         chartGPU.FanLabel = Labels.Get("gpu_fan");
         chartMid.FanLabel = Labels.Get("mid_fan");
+        headerUndervolt.Text = Labels.Get("undervolt_header");
+        labelUndervoltDesc.Text = Labels.Get("undervolt_desc");
+        labelUndervoltCpu.Text = Labels.Get("undervolt_cpu");
+        buttonApplyUV.Content = Labels.Get("apply");
+        buttonResetUV.Content = Labels.Get("reset");
+        checkApplyUV.Content = Labels.Get("undervolt_auto_apply");
     }
 
     // Fan Curves
@@ -514,7 +520,7 @@ public partial class FansWindow : Window
         return false;
     }
 
-    // ── Ryzen Curve Optimizer undervolt (mirrors Windows Fans.cs: trackUV / checkApplyUV) ──
+    // Ryzen Curve Optimizer undervolt (mirrors Windows Fans.cs: trackUV / checkApplyUV)
 
     private void LoadUV()
     {
@@ -549,7 +555,8 @@ public partial class FansWindow : Window
     private void SliderCpuUV_ValueChanged(object? sender,
         Avalonia.Controls.Primitives.RangeBaseValueChangedEventArgs e)
     {
-        if (_updatingUV) return;
+        if (_updatingUV)
+            return;
         // Slider value is positive intensity (0..40); config stores negated (−40..0).
         int intensity = Math.Clamp((int)e.NewValue, 0, -Platform.Linux.RyzenSmu.MinCPUUV);
         int cpuUV = -intensity;
@@ -577,7 +584,8 @@ public partial class FansWindow : Window
 
     private void CheckApplyUV_Changed(object? sender, RoutedEventArgs e)
     {
-        if (_updatingUV) return;
+        if (_updatingUV)
+            return;
         Helpers.AppConfig.SetMode("auto_uv", checkApplyUV.IsChecked == true ? 1 : 0);
         App.Mode?.AutoRyzen();
     }

--- a/src/UI/Views/FansWindow.axaml.cs
+++ b/src/UI/Views/FansWindow.axaml.cs
@@ -18,6 +18,7 @@ public partial class FansWindow : Window
     private readonly DispatcherTimer _sensorTimer;
     private System.Timers.Timer? _plDebounce;
     private bool _updatingPLSliders;
+    private bool _updatingUV;
 
     public FansWindow()
     {
@@ -41,6 +42,7 @@ public partial class FansWindow : Window
         {
             LoadFanCurves();
             LoadPowerLimits();
+            LoadUV();
             RefreshBoostButton();
             RefreshSensors();
             _sensorTimer.Start();
@@ -510,5 +512,72 @@ public partial class FansWindow : Window
                 return true;
         }
         return false;
+    }
+
+    // ── Ryzen Curve Optimizer undervolt (mirrors Windows Fans.cs: trackUV / checkApplyUV) ──
+
+    private void LoadUV()
+    {
+        var smu = App.Smu;
+        if (smu == null || !smu.IsAvailable)
+        {
+            panelUV.IsVisible = false;
+            return;
+        }
+
+        panelUV.IsVisible = true;
+
+        // Suppress ValueChanged/Checked handlers while programmatically populating controls —
+        // otherwise setting checkApplyUV.IsChecked would call AutoRyzen and apply UV to
+        // hardware just because the user opened the window.
+        _updatingUV = true;
+        try
+        {
+            int cpuUV = Helpers.AppConfig.GetMode("cpu_uv", 0);
+            cpuUV = Math.Clamp(cpuUV, Platform.Linux.RyzenSmu.MinCPUUV, Platform.Linux.RyzenSmu.MaxCPUUV);
+            sliderCpuUV.Value = cpuUV;
+            labelCpuUV.Text = cpuUV.ToString();
+            checkApplyUV.IsChecked = Helpers.AppConfig.IsMode("auto_uv");
+        }
+        finally
+        {
+            _updatingUV = false;
+        }
+    }
+
+    private void SliderCpuUV_ValueChanged(object? sender,
+        Avalonia.Controls.Primitives.RangeBaseValueChangedEventArgs e)
+    {
+        if (_updatingUV) return;
+        // Defense-in-depth: slider XAML already enforces [-40, 0] via Minimum/Maximum,
+        // but clamp here too so a bad value can never reach config → AutoRyzen on next boot.
+        int v = Math.Clamp((int)e.NewValue, Platform.Linux.RyzenSmu.MinCPUUV, Platform.Linux.RyzenSmu.MaxCPUUV);
+        labelCpuUV.Text = v.ToString();
+        Helpers.AppConfig.SetMode("cpu_uv", v);
+    }
+
+    private void ButtonApplyUV_Click(object? sender, RoutedEventArgs e) => App.Mode?.SetRyzen();
+
+    private void ButtonResetUV_Click(object? sender, RoutedEventArgs e)
+    {
+        _updatingUV = true;
+        try
+        {
+            sliderCpuUV.Value = 0;
+            labelCpuUV.Text = "0";
+        }
+        finally
+        {
+            _updatingUV = false;
+        }
+        Helpers.AppConfig.SetMode("cpu_uv", 0);
+        App.Mode?.ResetRyzen();
+    }
+
+    private void CheckApplyUV_Changed(object? sender, RoutedEventArgs e)
+    {
+        if (_updatingUV) return;
+        Helpers.AppConfig.SetMode("auto_uv", checkApplyUV.IsChecked == true ? 1 : 0);
+        App.Mode?.AutoRyzen();
     }
 }

--- a/src/UI/Views/FansWindow.axaml.cs
+++ b/src/UI/Views/FansWindow.axaml.cs
@@ -533,9 +533,10 @@ public partial class FansWindow : Window
         _updatingUV = true;
         try
         {
+            // Config stores negative cpu_uv (matches Windows); slider is 0..40 positive intensity.
             int cpuUV = Helpers.AppConfig.GetMode("cpu_uv", 0);
             cpuUV = Math.Clamp(cpuUV, Platform.Linux.RyzenSmu.MinCPUUV, Platform.Linux.RyzenSmu.MaxCPUUV);
-            sliderCpuUV.Value = cpuUV;
+            sliderCpuUV.Value = -cpuUV;
             labelCpuUV.Text = cpuUV.ToString();
             checkApplyUV.IsChecked = Helpers.AppConfig.IsMode("auto_uv");
         }
@@ -549,11 +550,11 @@ public partial class FansWindow : Window
         Avalonia.Controls.Primitives.RangeBaseValueChangedEventArgs e)
     {
         if (_updatingUV) return;
-        // Defense-in-depth: slider XAML already enforces [-40, 0] via Minimum/Maximum,
-        // but clamp here too so a bad value can never reach config → AutoRyzen on next boot.
-        int v = Math.Clamp((int)e.NewValue, Platform.Linux.RyzenSmu.MinCPUUV, Platform.Linux.RyzenSmu.MaxCPUUV);
-        labelCpuUV.Text = v.ToString();
-        Helpers.AppConfig.SetMode("cpu_uv", v);
+        // Slider value is positive intensity (0..40); config stores negated (−40..0).
+        int intensity = Math.Clamp((int)e.NewValue, 0, -Platform.Linux.RyzenSmu.MinCPUUV);
+        int cpuUV = -intensity;
+        labelCpuUV.Text = cpuUV.ToString();
+        Helpers.AppConfig.SetMode("cpu_uv", cpuUV);
     }
 
     private void ButtonApplyUV_Click(object? sender, RoutedEventArgs e) => App.Mode?.SetRyzen();


### PR DESCRIPTION
AMD Ryzen Curve Optimizer undervolting via the [ryzen_smu kernel driver][1]

***note**: I did vibe code this! Seems clean and works fine imo!*

[1]: https://github.com/amkillam/ryzen_smu

**Scope:** Raphael / Dragon Range family (codename 20) only.
Other generations are in the codename table but commented out.
Waiting on hardware testing before uncommenting.
*Does not persist on reboot for safety reasons!*

**UI:** Hidden unless driver loaded & cpu family supported.
<img width="953" height="1035" alt="image" src="https://github.com/user-attachments/assets/9ebccea3-691f-4890-8c7a-dd2c798fd5e6" />

### Dependency
Requires [amkillam/ryzen_smu][2] , a community-maintained (not AMD or mainline) out-of-tree kernel module that exposes the SMU mailbox via sysfs.
Without it, the feature silently disables (panel hidden, log notes absent).
Install via AUR `ryzen_smu-dkms-git` on Arch, or build from source.
I know the purpose of this repo is to have 0 dependencies, but I personally liked this feature the most for my toasty cpu back when I was on windows. So I will definitely continue using it for myself!

[2]: https://github.com/amkillam/ryzen_smu

### Tests

AMD Ryzen 9 7845HX, 20 s stress-ng, CO=-28 vs 0:

|            | 0       | -28     |
|------------|---------|---------|
| Avg MHz    | 4331    | **4506** |
| Pkg power  | 94.8 W  | 95.5 W  |
| Tctl       | 95.6 °C | 95.6 °C |

+175 MHz at same power and temp, consistent across 5 runs.