### PR TITLE
Create /etc/ghelper so the GPU-boot service stops spamming the journal (#116)

### DIFF
--- a/install/ghelper-gpu-boot.service
+++ b/install/ghelper-gpu-boot.service
@@ -45,6 +45,10 @@ ProtectHome=true
 
 # /sys, /dev, /proc remain writable under ProtectSystem=strict by default.
 # Explicit RW paths for our config + block artifacts + udev socket.
+# ConfigurationDirectory creates /etc/ghelper (0755, root) BEFORE ExecStart and adds it to
+# the writable set. Without it, a missing /etc/ghelper makes ProtectSystem=strict fail the
+# mount-namespace setup on every boot, spamming the journal (see issue #116).
+ConfigurationDirectory=ghelper
 ReadWritePaths=/etc/ghelper
 ReadWritePaths=/etc/modprobe.d
 ReadWritePaths=/etc/udev/rules.d

--- a/install/install-local.sh
+++ b/install/install-local.sh
@@ -411,6 +411,12 @@ if [[ "$MODE" != "appimage" ]]; then
     _install_file "$BOOT_SCRIPT_SRC" "$BOOT_SCRIPT_DEST" 755 "GPU boot script" || true
     _install_file "$BOOT_UNIT_SRC" "$BOOT_UNIT_DEST" 644 "GPU boot systemd unit" || true
 
+    # Config dir for boot-service artifacts. The unit also creates this via
+    # ConfigurationDirectory=, but make it now so upgrades don't depend on a reboot — a
+    # missing /etc/ghelper makes the unit's ProtectSystem=strict namespace setup fail and
+    # spam the journal (issue #116).
+    mkdir -p /etc/ghelper && chmod 0755 /etc/ghelper 2>/dev/null || true
+
     # Reload systemd so it picks up the new/changed unit file
     systemctl daemon-reload 2>/dev/null || true
     _info "systemd daemon-reload"

--- a/install/install.sh
+++ b/install/install.sh
@@ -442,6 +442,12 @@ if [[ "$MODE" == "install" ]]; then
     _install_file "$WORK_DIR/ghelper-gpu-boot.sh" "$HELPER_DIR/ghelper-gpu-boot.sh" 755 "GPU boot script" || true
     _install_file "$WORK_DIR/ghelper-gpu-boot.service" "/etc/systemd/system/ghelper-gpu-boot.service" 644 "GPU boot systemd unit" || true
 
+    # Config dir for boot-service artifacts. The unit also creates this via
+    # ConfigurationDirectory=, but make it now so upgrades don't depend on a reboot — a
+    # missing /etc/ghelper makes the unit's ProtectSystem=strict namespace setup fail and
+    # spam the journal (issue #116).
+    mkdir -p /etc/ghelper && chmod 0755 /etc/ghelper 2>/dev/null || true
+
     GPU_HELPER_DEST="$INSTALL_DIR/gpu-helper"
     if "$INSTALL_DIR/ghelper" --extract-helper gpu-helper "$GPU_HELPER_DEST" >/dev/null 2>&1; then
         chown root:root "$GPU_HELPER_DEST"


### PR DESCRIPTION
## What

Fixes the remaining journal-spam source in #116.

`ghelper-gpu-boot.service` runs under `ProtectSystem=strict` and declares
`ReadWritePaths=/etc/ghelper`, but nothing ever created that directory — the installers
only *remove* it on uninstall, and the boot script's own `mkdir -p /etc/ghelper` runs
*after* the namespace is built. When `/etc/ghelper` is missing, systemd cannot set up the
unit's mount namespace and the service **fails on every boot**, logging errors. This is the
issue the maintainer worked around in the thread by telling the reporter to run
`sudo mkdir -p /etc/ghelper`.

## Changes

- **`ghelper-gpu-boot.service`**: add `ConfigurationDirectory=ghelper` so systemd creates
  `/etc/ghelper` (0755, root) **before** `ExecStart`, regardless of install path. This
  fixes the spam even on machines that never re-run the installer.
- **`install.sh` / `install-local.sh`**: also `mkdir -p /etc/ghelper` during install so
  existing installs are fixed immediately, without waiting for a reboot.

## Note on the udev half of #116

The udev-rule parse errors quoted in the issue (lines 52/119/… with single-`$` shell
variables) were **already fixed on master** in `72da539` and `3b0199f`. `udevadm verify`
on master is clean; v1.0.79 reports 8 errors. That fix just isn't in a release tag yet, so
v1.0.79 users still see it. This PR addresses the *other*, still-unfixed spam source.

## Verification

- `systemd-analyze verify install/ghelper-gpu-boot.service` → clean
- `udevadm verify install/90-ghelper.rules` → `Success: 1, Fail: 0` (unchanged)
- `bash install/tests/test-ghelper-gpu-boot.sh` → 73/73 pass
- `bash -n` on both installers → OK