### PR TITLE
Fix silent gpu-helper embed regression in v1.0.84; add CI smoke test

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -70,13 +70,52 @@ jobs:
           dotnet-version: '10.0'
 
       - name: Install Native AOT dependencies
-        run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev libwayland-dev upx-ucl libpipewire-0.3-dev pkg-config
+        run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev libwayland-dev upx-ucl libpipewire-0.3-dev libpci-dev pkg-config
 
       - name: Restore packages
         run: dotnet restore src/ --runtime linux-x64
 
       - name: Build
         run: ./build.sh
+
+      - name: Verify embedded resources
+        run: |
+          set -e
+          cd dist
+          # Resources the binary must embed (LogicalName from csproj).
+          # A missing or zero-size embed here means the build silently produced
+          # a non-functional binary (catches cc failure, missing dev headers,
+          # MSBuild Condition cache poisoning, etc).
+          EXPECTED=(
+            gpu-helper
+            gpu-block-helper.sh
+            ghelper-gpu-boot.sh
+            90-ghelper.rules
+            libSkiaSharp.so
+            libHarfBuzzSharp.so
+            ghelper-audio
+            wlr-randr
+          )
+          for res in "${EXPECTED[@]}"; do
+            out="/tmp/smoke-${res}"
+            rm -f "$out"
+            if ! ./ghelper --extract-helper "$res" "$out" >/dev/null 2>&1; then
+              echo "ERROR: embedded resource '$res' not found in binary"
+              exit 1
+            fi
+            size=$(stat -c%s "$out")
+            if (( size < 100 )); then
+              echo "ERROR: embedded resource '$res' is suspiciously small ($size bytes)"
+              exit 1
+            fi
+            echo "  ok: $res ($size bytes)"
+          done
+          # gpu-helper must be a valid ELF executable (not a zero-byte placeholder).
+          if ! file /tmp/smoke-gpu-helper | grep -q "ELF.*executable"; then
+            echo "ERROR: gpu-helper is not a valid ELF executable"
+            exit 1
+          fi
+          echo "All embedded resources verified"
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,13 +72,52 @@ jobs:
           dotnet-version: '10.0'
 
       - name: Install Native AOT dependencies
-        run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev libwayland-dev upx-ucl libpipewire-0.3-dev pkg-config
+        run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev libwayland-dev upx-ucl libpipewire-0.3-dev libpci-dev pkg-config
 
       - name: Restore packages
         run: dotnet restore src/ --runtime linux-x64
 
       - name: Build
         run: ./build.sh
+
+      - name: Verify embedded resources
+        run: |
+          set -e
+          cd dist
+          # Resources the binary must embed (LogicalName from csproj).
+          # A missing or zero-size embed here means the build silently produced
+          # a non-functional binary (catches cc failure, missing dev headers,
+          # MSBuild Condition cache poisoning, etc).
+          EXPECTED=(
+            gpu-helper
+            gpu-block-helper.sh
+            ghelper-gpu-boot.sh
+            90-ghelper.rules
+            libSkiaSharp.so
+            libHarfBuzzSharp.so
+            ghelper-audio
+            wlr-randr
+          )
+          for res in "${EXPECTED[@]}"; do
+            out="/tmp/smoke-${res}"
+            rm -f "$out"
+            if ! ./ghelper --extract-helper "$res" "$out" >/dev/null 2>&1; then
+              echo "ERROR: embedded resource '$res' not found in binary"
+              exit 1
+            fi
+            size=$(stat -c%s "$out")
+            if (( size < 100 )); then
+              echo "ERROR: embedded resource '$res' is suspiciously small ($size bytes)"
+              exit 1
+            fi
+            echo "  ok: $res ($size bytes)"
+          done
+          # gpu-helper must be a valid ELF executable (not a zero-byte placeholder).
+          if ! file /tmp/smoke-gpu-helper | grep -q "ELF.*executable"; then
+            echo "ERROR: gpu-helper is not a valid ELF executable"
+            exit 1
+          fi
+          echo "All embedded resources verified"
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4

--- a/build.sh
+++ b/build.sh
@@ -164,7 +164,9 @@ if command -v cc &>/dev/null; then
         GPU_HELPER_BIN="$GPU_HELPER_DIR/gpu-helper"
         echo "  gpu-helper built: $(du -sh "$GPU_HELPER_BIN" | cut -f1)"
     else
-        echo "WARNING: gpu-helper build failed (privileged GPU operations unavailable)"
+        echo "ERROR: gpu-helper build failed (privileged GPU operations unavailable)"
+        echo "  Check: 'cc' is installed and libpci-dev is present (apt: libpci-dev)"
+        exit 1
     fi
 else
     echo ""
@@ -178,7 +180,8 @@ if (( USE_AOT )); then
     echo "[1/4] Cleaning previous build..."
     rm -rf "$SRC_DIR/bin/Release" 2>/dev/null || true
 else
-    echo "[1/4] Skipping clean (fast mode, incremental build)"
+    echo "[1/4] Cleaning (fast mode) to force MSBuild condition re-evaluation..."
+    rm -rf "$SRC_DIR/bin/Release" "$SRC_DIR/obj/Release" 2>/dev/null || true
 fi
 
 # Restore packages

--- a/src/GHelper.Linux.csproj
+++ b/src/GHelper.Linux.csproj
@@ -96,7 +96,7 @@
       <!-- ghelper-audio: PipeWire helper with bundled rnnoise + parametric EQ + delay + reverb DSP.
            Built by build.sh from audio-helper/. Provides the virtual G-Helper Microphone source. -->
       <EmbeddedResource Include="../build/embedded/ghelper-audio" Condition="Exists('../build/embedded/ghelper-audio')" LogicalName="ghelper-audio" />
-      <EmbeddedResource Include="../vendor/gpu-helper/gpu-helper" Condition="Exists('../vendor/gpu-helper/gpu-helper')" LogicalName="gpu-helper" />
+      <EmbeddedResource Include="../vendor/gpu-helper/gpu-helper" LogicalName="gpu-helper" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
v1.0.84's CI runner lacked libpci-dev, so gpu-helper was never built and the embed was silently missing. build.sh now hard-fails on cc errors, the csproj Condition is removed, CI gets libpci-dev + a smoke test that verifies every embedded resource.