### PR TITLE
Fix udev platform_profile false failure logs

### DIFF
--- a/install/90-ghelper.rules
+++ b/install/90-ghelper.rules
@@ -28,12 +28,12 @@ ACTION=="add|change", SUBSYSTEM=="module", KERNEL=="acpi_cpufreq", \
 # CPU device trigger — catches built-in drivers (intel_pstate, amd_pstate) that don't
 # fire module events. Also sets platform_profile permissions.
 SUBSYSTEM=="cpu", ACTION=="add", \
-  RUN+="/bin/sh -c '[ -f /sys/devices/system/cpu/intel_pstate/no_turbo ] && chmod 0666 /sys/devices/system/cpu/intel_pstate/no_turbo; [ -f /sys/devices/system/cpu/cpufreq/boost ] && chmod 0666 /sys/devices/system/cpu/cpufreq/boost; [ -f /sys/firmware/acpi/platform_profile ] && chmod 0666 /sys/firmware/acpi/platform_profile'"
+  RUN+="/bin/sh -c '[ -f /sys/devices/system/cpu/intel_pstate/no_turbo ] && chmod 0666 /sys/devices/system/cpu/intel_pstate/no_turbo; [ -f /sys/devices/system/cpu/cpufreq/boost ] && chmod 0666 /sys/devices/system/cpu/cpufreq/boost; [ ! -f /sys/firmware/acpi/platform_profile ] || chmod 0666 /sys/firmware/acpi/platform_profile'"
 
 # ── ACPI platform profile ──
 # Allow non-root to set platform profile (balanced/performance/low-power)
 ACTION=="add|change", SUBSYSTEM=="acpi", \
-  RUN+="/bin/sh -c '[ -f /sys/firmware/acpi/platform_profile ] && chmod 0666 /sys/firmware/acpi/platform_profile'"
+  RUN+="/bin/sh -c '[ ! -f /sys/firmware/acpi/platform_profile ] || chmod 0666 /sys/firmware/acpi/platform_profile'"
 
 # ── Backlight ──
 SUBSYSTEM=="backlight", ACTION=="add", \
@@ -167,7 +167,7 @@ SUBSYSTEM=="platform", DRIVER=="asus-nb-wmi", \
 # dedicated module/cpu/acpi triggers are unreliable on some distros
 # (Bazzite/Fedora Atomic: intel_pstate built-in, CPU add fires too early).
 SUBSYSTEM=="platform", DRIVER=="asus-nb-wmi", \
-  RUN+="/bin/sh -c '[ -f /sys/firmware/acpi/platform_profile ] && chmod 0666 /sys/firmware/acpi/platform_profile'"
+  RUN+="/bin/sh -c '[ ! -f /sys/firmware/acpi/platform_profile ] || chmod 0666 /sys/firmware/acpi/platform_profile'"
 
 SUBSYSTEM=="platform", DRIVER=="asus-nb-wmi", \
   RUN+="/bin/sh -c '[ -f /sys/devices/system/cpu/intel_pstate/no_turbo ] && chmod 0666 /sys/devices/system/cpu/intel_pstate/no_turbo; [ -f /sys/devices/system/cpu/cpufreq/boost ] && chmod 0666 /sys/devices/system/cpu/cpufreq/boost'"
@@ -270,7 +270,7 @@ ACTION=="add|change", SUBSYSTEM=="platform", DRIVER=="ideapad_acpi", \
 # asus-nb-wmi rule above, bound to ideapad_acpi which all consumer Lenovo
 # laptops (IdeaPad/Legion/LOQ/Yoga) expose
 SUBSYSTEM=="platform", DRIVER=="ideapad_acpi", \
-  RUN+="/bin/sh -c '[ -f /sys/firmware/acpi/platform_profile ] && chmod 0666 /sys/firmware/acpi/platform_profile'"
+  RUN+="/bin/sh -c '[ ! -f /sys/firmware/acpi/platform_profile ] || chmod 0666 /sys/firmware/acpi/platform_profile'"
 
 SUBSYSTEM=="platform", DRIVER=="ideapad_acpi", \
   RUN+="/bin/sh -c '[ -f /sys/devices/system/cpu/intel_pstate/no_turbo ] && chmod 0666 /sys/devices/system/cpu/intel_pstate/no_turbo; [ -f /sys/devices/system/cpu/cpufreq/boost ] && chmod 0666 /sys/devices/system/cpu/cpufreq/boost'"
@@ -279,7 +279,7 @@ SUBSYSTEM=="platform", DRIVER=="ideapad_acpi", \
 # module event as fallback trigger when ideapad binds before the profile
 # provider registers
 ACTION=="add|change", SUBSYSTEM=="module", KERNEL=="lenovo_wmi_gamezone", \
-  RUN+="/bin/sh -c 'sleep 1; [ -f /sys/firmware/acpi/platform_profile ] && chmod 0666 /sys/firmware/acpi/platform_profile'"
+  RUN+="/bin/sh -c 'sleep 1; [ ! -f /sys/firmware/acpi/platform_profile ] || chmod 0666 /sys/firmware/acpi/platform_profile'"
 
 # Lenovo keyboard backlight LED (platform::kbd_backlight)
 SUBSYSTEM=="leds", KERNEL=="platform::kbd_backlight*", \


### PR DESCRIPTION
The platform_profile permission commands currently use a positive file test followed by && chmod. When the sysfs node is not available yet, the test exits with status 1, so systemd-udevd reports the RUN command as failed for every matching device event. On an ASUS G533QS this produced 158 warnings during one boot even though the node appeared later and received the correct permissions.\n\nUse an inverted existence test followed by || chmod instead. This preserves the chmod behavior when the node exists while returning success when it is not available yet. The change covers the CPU, generic ACPI, ASUS and Lenovo platform_profile triggers.\n\nValidation: udevadm verify install/90-ghelper.rules reports 1 success and 0 failures.