### PR TITLE
Release aug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@
 
 ### Changed
 
+## v1.0.91 (2026-08-19)
+
+### Added
+
+- XG Mobile: dock panel hints to add `pcie_port_pm=off` when live switching hangs (#171).
+
+### Fixed
+
+- udev rules return success when a node is absent, so systemd-udevd stops logging false RUN failures (#165, thanks @tlamoureux24).
+
+### Changed
+
+- Svg.Controls.Skia.Avalonia 12.0.0.15, ILCompiler 10.0.10.
+
 ## v1.0.90 (2026-08-02)
 
 ### Added

--- a/nixos/deps.json
+++ b/nixos/deps.json
@@ -126,13 +126,13 @@
   },
   {
     "pname": "Microsoft.DotNet.ILCompiler",
-    "version": "10.0.9",
-    "hash": "sha256-/lk5pFop4Z70fx34WRlyEHA9gEtzx05C24ha3pezgXo="
+    "version": "10.0.10",
+    "hash": "sha256-0zo0jQSdcdRk7caJsfFsu+v18lTLFIxqkVTf1QWqg3g="
   },
   {
     "pname": "Microsoft.NET.ILLink.Tasks",
-    "version": "10.0.9",
-    "hash": "sha256-i83w0RDOcaHz6I7jIAjR2abJtQwn5N8ePu1ySqh/4S4="
+    "version": "10.0.10",
+    "hash": "sha256-l6DsogMJAXOPBw8UKq8Cs7GurSvJhMCMQohHkQtL4xI="
   },
   {
     "pname": "ShimSkiaSharp",

--- a/src/GHelper.Linux.csproj
+++ b/src/GHelper.Linux.csproj
@@ -53,7 +53,7 @@
 
     <!-- Real-time monitoring charts -->
     <PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.1.0-dev-798" />
-    <PackageReference Include="Svg.Controls.Skia.Avalonia" Version="12.0.0.13" />
+    <PackageReference Include="Svg.Controls.Skia.Avalonia" Version="12.0.0.15" />
   </ItemGroup>
 
   <!-- Embed all assets -->

--- a/src/Gpu/NVidia/NvidiaProcessScanner.cs
+++ b/src/Gpu/NVidia/NvidiaProcessScanner.cs
@@ -125,8 +125,10 @@ public static class NvidiaProcessScanner
     private static string FormatHolderBrief(int pid, string comm, string user, int fds, int dri, int i2c)
     {
         string s = $"{pid}:{comm}({user})/{fds}fds";
-        if (dri > 0) s += $"+{dri}dri";
-        if (i2c > 0) s += $"+{i2c}i2c";
+        if (dri > 0)
+            s += $"+{dri}dri";
+        if (i2c > 0)
+            s += $"+{i2c}i2c";
         return s;
     }
 

--- a/src/I18n/Languages/Arabic.cs
+++ b/src/I18n/Languages/Arabic.cs
@@ -768,6 +768,7 @@ public static class Arabic
         ["xgm_extra_header"] = "قاعدة XG Mobile",
         ["xgm_extra_lights_label"] = "إضاءة القاعدة",
         ["xgm_extra_brightness_label"] = "السطوع",
+        ["xgm_pcie_pm_hint"] = "إذا تعطل التبديل المباشر، أضف pcie_port_pm=off إلى سطر أوامر النواة.",
         ["xgm_fan"] = "مروحة XG Mobile",
         ["confirm_yes"] = "نعم",
         ["confirm_no"] = "لا",

--- a/src/I18n/Languages/Bengali.cs
+++ b/src/I18n/Languages/Bengali.cs
@@ -890,6 +890,7 @@ public static class Bengali
         ["xgm_extra_header"] = "XG Mobile ডক",
         ["xgm_extra_lights_label"] = "ডকের আলো",
         ["xgm_extra_brightness_label"] = "উজ্জ্বলতা",
+        ["xgm_pcie_pm_hint"] = "লাইভ স্যুইচিং আটকে গেলে কার্নেল কমান্ড লাইনে pcie_port_pm=off যোগ করুন।",
         ["xgm_fan"] = "XG Mobile ফ্যান",
 
         // Reusable confirm-dialog buttons (used by ConfirmDialog and any

--- a/src/I18n/Languages/ChineseSimplified.cs
+++ b/src/I18n/Languages/ChineseSimplified.cs
@@ -768,6 +768,7 @@ public static class ChineseSimplified
         ["xgm_extra_header"] = "XG Mobile 扩展坞",
         ["xgm_extra_lights_label"] = "扩展坞灯光",
         ["xgm_extra_brightness_label"] = "亮度",
+        ["xgm_pcie_pm_hint"] = "如果实时切换卡住，请在内核命令行中添加 pcie_port_pm=off。",
         ["xgm_fan"] = "XG Mobile 风扇",
         ["confirm_yes"] = "是",
         ["confirm_no"] = "否",

--- a/src/I18n/Languages/ChineseTraditional.cs
+++ b/src/I18n/Languages/ChineseTraditional.cs
@@ -768,6 +768,7 @@ public static class ChineseTraditional
         ["xgm_extra_header"] = "XG Mobile 擴充基座",
         ["xgm_extra_lights_label"] = "基座燈光",
         ["xgm_extra_brightness_label"] = "亮度",
+        ["xgm_pcie_pm_hint"] = "如果即時切換卡住，請在核心命令列中加入 pcie_port_pm=off。",
         ["xgm_fan"] = "XG Mobile 風扇",
         ["confirm_yes"] = "是",
         ["confirm_no"] = "否",

--- a/src/I18n/Languages/Czech.cs
+++ b/src/I18n/Languages/Czech.cs
@@ -765,6 +765,7 @@ public static class Czech
         ["xgm_extra_header"] = "Dok XG Mobile",
         ["xgm_extra_lights_label"] = "Osvětlení doku",
         ["xgm_extra_brightness_label"] = "Jas",
+        ["xgm_pcie_pm_hint"] = "Pokud se přepínání za běhu zasekne, přidejte pcie_port_pm=off na příkazový řádek jádra.",
         ["xgm_fan"] = "Ventilátor XG Mobile",
         ["confirm_yes"] = "Ano",
         ["confirm_no"] = "Ne",

--- a/src/I18n/Languages/Danish.cs
+++ b/src/I18n/Languages/Danish.cs
@@ -768,6 +768,7 @@ public static class Danish
         ["xgm_extra_header"] = "XG Mobile-dok",
         ["xgm_extra_lights_label"] = "Doklys",
         ["xgm_extra_brightness_label"] = "Lysstyrke",
+        ["xgm_pcie_pm_hint"] = "Hvis live-skift hænger, tilføj pcie_port_pm=off til kernens kommandolinje.",
         ["xgm_fan"] = "XG Mobile-blæser",
         ["confirm_yes"] = "Ja",
         ["confirm_no"] = "Nej",

--- a/src/I18n/Languages/Dutch.cs
+++ b/src/I18n/Languages/Dutch.cs
@@ -765,6 +765,7 @@ public static class Dutch
         ["xgm_extra_header"] = "XG Mobile-dock",
         ["xgm_extra_lights_label"] = "Dockverlichting",
         ["xgm_extra_brightness_label"] = "Helderheid",
+        ["xgm_pcie_pm_hint"] = "Als live schakelen vastloopt, voeg pcie_port_pm=off toe aan de kernel-opdrachtregel.",
         ["xgm_fan"] = "XG Mobile-ventilator",
         ["confirm_yes"] = "Ja",
         ["confirm_no"] = "Nee",

--- a/src/I18n/Languages/English.cs
+++ b/src/I18n/Languages/English.cs
@@ -893,6 +893,7 @@ public static class English
         ["xgm_extra_header"] = "XG Mobile Dock",
         ["xgm_extra_lights_label"] = "Dock lights",
         ["xgm_extra_brightness_label"] = "Brightness",
+        ["xgm_pcie_pm_hint"] = "If live switching hangs, add pcie_port_pm=off to the kernel command line.",
         ["xgm_fan"] = "XG Mobile Fan",
 
         // Reusable confirm-dialog buttons (used by ConfirmDialog and any

--- a/src/I18n/Languages/Filipino.cs
+++ b/src/I18n/Languages/Filipino.cs
@@ -890,6 +890,7 @@ public static class Filipino
         ["xgm_extra_header"] = "XG Mobile Dock",
         ["xgm_extra_lights_label"] = "Mga ilaw ng dock",
         ["xgm_extra_brightness_label"] = "Brightness",
+        ["xgm_pcie_pm_hint"] = "Kung nahahang ang live switching, idagdag ang pcie_port_pm=off sa kernel command line.",
         ["xgm_fan"] = "XG Mobile Fan",
 
         // Reusable confirm-dialog buttons (used by ConfirmDialog and any

--- a/src/I18n/Languages/Finnish.cs
+++ b/src/I18n/Languages/Finnish.cs
@@ -768,6 +768,7 @@ public static class Finnish
         ["xgm_extra_header"] = "XG Mobile -telakka",
         ["xgm_extra_lights_label"] = "Telakan valot",
         ["xgm_extra_brightness_label"] = "Kirkkaus",
+        ["xgm_pcie_pm_hint"] = "Jos vaihto lennossa jumiutuu, lisää pcie_port_pm=off ytimen komentoriville.",
         ["xgm_fan"] = "XG Mobile -tuuletin",
         ["confirm_yes"] = "Kyllä",
         ["confirm_no"] = "Ei",

--- a/src/I18n/Languages/French.cs
+++ b/src/I18n/Languages/French.cs
@@ -765,6 +765,7 @@ public static class French
         ["xgm_extra_header"] = "Dock XG Mobile",
         ["xgm_extra_lights_label"] = "Éclairage du dock",
         ["xgm_extra_brightness_label"] = "Luminosité",
+        ["xgm_pcie_pm_hint"] = "Si la commutation à chaud se bloque, ajoutez pcie_port_pm=off à la ligne de commande du noyau.",
         ["xgm_fan"] = "Ventilateur XG Mobile",
         ["confirm_yes"] = "Oui",
         ["confirm_no"] = "Non",

--- a/src/I18n/Languages/German.cs
+++ b/src/I18n/Languages/German.cs
@@ -765,6 +765,7 @@ public static class German
         ["xgm_extra_header"] = "XG-Mobile-Dock",
         ["xgm_extra_lights_label"] = "Dock-Beleuchtung",
         ["xgm_extra_brightness_label"] = "Helligkeit",
+        ["xgm_pcie_pm_hint"] = "Wenn das Umschalten im Betrieb hängt, pcie_port_pm=off zur Kernel-Befehlszeile hinzufügen.",
         ["xgm_fan"] = "XG-Mobile-Lüfter",
         ["confirm_yes"] = "Ja",
         ["confirm_no"] = "Nein",

--- a/src/I18n/Languages/Greek.cs
+++ b/src/I18n/Languages/Greek.cs
@@ -768,6 +768,7 @@ public static class Greek
         ["xgm_extra_header"] = "Dock XG Mobile",
         ["xgm_extra_lights_label"] = "Φώτα dock",
         ["xgm_extra_brightness_label"] = "Φωτεινότητα",
+        ["xgm_pcie_pm_hint"] = "Αν η εναλλαγή σε πραγματικό χρόνο κολλήσει, προσθέστε pcie_port_pm=off στη γραμμή εντολών του πυρήνα.",
         ["xgm_fan"] = "Ανεμιστήρας XG Mobile",
         ["confirm_yes"] = "Ναι",
         ["confirm_no"] = "Όχι",

--- a/src/I18n/Languages/Hindi.cs
+++ b/src/I18n/Languages/Hindi.cs
@@ -890,6 +890,7 @@ public static class Hindi
         ["xgm_extra_header"] = "XG Mobile डॉक",
         ["xgm_extra_lights_label"] = "डॉक लाइट्स",
         ["xgm_extra_brightness_label"] = "चमक",
+        ["xgm_pcie_pm_hint"] = "यदि लाइव स्विचिंग अटक जाए, तो कर्नेल कमांड लाइन में pcie_port_pm=off जोड़ें।",
         ["xgm_fan"] = "XG Mobile पंखा",
 
         // Reusable confirm-dialog buttons (used by ConfirmDialog and any

--- a/src/I18n/Languages/Hungarian.cs
+++ b/src/I18n/Languages/Hungarian.cs
@@ -765,6 +765,7 @@ public static class Hungarian
         ["xgm_extra_header"] = "XG Mobile dokkoló",
         ["xgm_extra_lights_label"] = "Dokkoló fények",
         ["xgm_extra_brightness_label"] = "Fényerő",
+        ["xgm_pcie_pm_hint"] = "Ha a menet közbeni váltás megakad, add hozzá a pcie_port_pm=off paramétert a kernel parancssorához.",
         ["xgm_fan"] = "XG Mobile ventilátor",
         ["confirm_yes"] = "Igen",
         ["confirm_no"] = "Nem",

--- a/src/I18n/Languages/Indonesian.cs
+++ b/src/I18n/Languages/Indonesian.cs
@@ -768,6 +768,7 @@ public static class Indonesian
         ["xgm_extra_header"] = "Dock XG Mobile",
         ["xgm_extra_lights_label"] = "Lampu dock",
         ["xgm_extra_brightness_label"] = "Kecerahan",
+        ["xgm_pcie_pm_hint"] = "Jika peralihan langsung macet, tambahkan pcie_port_pm=off ke baris perintah kernel.",
         ["xgm_fan"] = "Kipas XG Mobile",
         ["confirm_yes"] = "Ya",
         ["confirm_no"] = "Tidak",

--- a/src/I18n/Languages/Italian.cs
+++ b/src/I18n/Languages/Italian.cs
@@ -765,6 +765,7 @@ public static class Italian
         ["xgm_extra_header"] = "Dock XG Mobile",
         ["xgm_extra_lights_label"] = "Luci del dock",
         ["xgm_extra_brightness_label"] = "Luminosità",
+        ["xgm_pcie_pm_hint"] = "Se il cambio a caldo si blocca, aggiungi pcie_port_pm=off alla riga di comando del kernel.",
         ["xgm_fan"] = "Ventola XG Mobile",
         ["confirm_yes"] = "Sì",
         ["confirm_no"] = "No",

--- a/src/I18n/Languages/Japanese.cs
+++ b/src/I18n/Languages/Japanese.cs
@@ -768,6 +768,7 @@ public static class Japanese
         ["xgm_extra_header"] = "XG Mobile ドック",
         ["xgm_extra_lights_label"] = "ドックライト",
         ["xgm_extra_brightness_label"] = "明るさ",
+        ["xgm_pcie_pm_hint"] = "ライブ切り替えが停止する場合は、カーネルコマンドラインに pcie_port_pm=off を追加してください。",
         ["xgm_fan"] = "XG Mobile ファン",
         ["confirm_yes"] = "はい",
         ["confirm_no"] = "いいえ",

--- a/src/I18n/Languages/Korean.cs
+++ b/src/I18n/Languages/Korean.cs
@@ -768,6 +768,7 @@ public static class Korean
         ["xgm_extra_header"] = "XG Mobile 도크",
         ["xgm_extra_lights_label"] = "도크 조명",
         ["xgm_extra_brightness_label"] = "밝기",
+        ["xgm_pcie_pm_hint"] = "실시간 전환이 멈추면 커널 명령줄에 pcie_port_pm=off 를 추가하세요.",
         ["xgm_fan"] = "XG Mobile 팬",
         ["confirm_yes"] = "예",
         ["confirm_no"] = "아니오",

--- a/src/I18n/Languages/Latvian.cs
+++ b/src/I18n/Languages/Latvian.cs
@@ -890,6 +890,7 @@ public static class Latvian
         ["xgm_extra_header"] = "XG Mobile doks",
         ["xgm_extra_lights_label"] = "Doka gaismas",
         ["xgm_extra_brightness_label"] = "Spilgtums",
+        ["xgm_pcie_pm_hint"] = "Ja pārslēgšana darbības laikā iestrēgst, pievienojiet pcie_port_pm=off kodola komandrindai.",
         ["xgm_fan"] = "XG Mobile ventilators",
 
         // Reusable confirm-dialog buttons (used by ConfirmDialog and any

--- a/src/I18n/Languages/Lithuanian.cs
+++ b/src/I18n/Languages/Lithuanian.cs
@@ -890,6 +890,7 @@ public static class Lithuanian
         ["xgm_extra_header"] = "XG Mobile dokas",
         ["xgm_extra_lights_label"] = "Doko šviesos",
         ["xgm_extra_brightness_label"] = "Ryškumas",
+        ["xgm_pcie_pm_hint"] = "Jei perjungimas veikiant užstringa, pridėkite pcie_port_pm=off į branduolio komandų eilutę.",
         ["xgm_fan"] = "XG Mobile ventiliatorius",
 
         // Reusable confirm-dialog buttons (used by ConfirmDialog and any

--- a/src/I18n/Languages/Macedonian.cs
+++ b/src/I18n/Languages/Macedonian.cs
@@ -768,6 +768,7 @@ public static class Macedonian
         ["xgm_extra_header"] = "XG Mobile докинг станица",
         ["xgm_extra_lights_label"] = "Светла на станицата",
         ["xgm_extra_brightness_label"] = "Осветленост",
+        ["xgm_pcie_pm_hint"] = "Ако префрлањето во работа блокира, додајте pcie_port_pm=off во командната линија на кернелот.",
         ["xgm_fan"] = "Вентилатор за XG Mobile",
         ["confirm_yes"] = "Да",
         ["confirm_no"] = "Не",

--- a/src/I18n/Languages/Malay.cs
+++ b/src/I18n/Languages/Malay.cs
@@ -890,6 +890,7 @@ public static class Malay
         ["xgm_extra_header"] = "Dok XG Mobile",
         ["xgm_extra_lights_label"] = "Lampu dok",
         ["xgm_extra_brightness_label"] = "Kecerahan",
+        ["xgm_pcie_pm_hint"] = "Jika penukaran langsung tersekat, tambah pcie_port_pm=off pada baris perintah kernel.",
         ["xgm_fan"] = "Kipas XG Mobile",
 
         // Reusable confirm-dialog buttons (used by ConfirmDialog and any

--- a/src/I18n/Languages/Nepali.cs
+++ b/src/I18n/Languages/Nepali.cs
@@ -890,6 +890,7 @@ public static class Nepali
         ["xgm_extra_header"] = "XG Mobile डक",
         ["xgm_extra_lights_label"] = "डक बत्तीहरू",
         ["xgm_extra_brightness_label"] = "चमक",
+        ["xgm_pcie_pm_hint"] = "लाइभ स्विचिङ अड्किएमा कर्नेल कमाण्ड लाइनमा pcie_port_pm=off थप्नुहोस्।",
         ["xgm_fan"] = "XG Mobile पङ्खा",
 
         // Reusable confirm-dialog buttons (used by ConfirmDialog and any

--- a/src/I18n/Languages/Norwegian.cs
+++ b/src/I18n/Languages/Norwegian.cs
@@ -768,6 +768,7 @@ public static class Norwegian
         ["xgm_extra_header"] = "XG Mobile-dokk",
         ["xgm_extra_lights_label"] = "Dokk-lys",
         ["xgm_extra_brightness_label"] = "Lysstyrke",
+        ["xgm_pcie_pm_hint"] = "Hvis bytte under drift henger, legg til pcie_port_pm=off på kjernens kommandolinje.",
         ["xgm_fan"] = "XG Mobile-vifte",
         ["confirm_yes"] = "Ja",
         ["confirm_no"] = "Nei",

--- a/src/I18n/Languages/Polish.cs
+++ b/src/I18n/Languages/Polish.cs
@@ -765,6 +765,7 @@ public static class Polish
         ["xgm_extra_header"] = "Stacja dokująca XG Mobile",
         ["xgm_extra_lights_label"] = "Podświetlenie stacji",
         ["xgm_extra_brightness_label"] = "Jasność",
+        ["xgm_pcie_pm_hint"] = "Jeśli przełączanie na gorąco się zawiesza, dodaj pcie_port_pm=off do wiersza poleceń jądra.",
         ["xgm_fan"] = "Wentylator XG Mobile",
         ["confirm_yes"] = "Tak",
         ["confirm_no"] = "Nie",

--- a/src/I18n/Languages/PortugueseBR.cs
+++ b/src/I18n/Languages/PortugueseBR.cs
@@ -765,6 +765,7 @@ public static class PortugueseBR
         ["xgm_extra_header"] = "Dock XG Mobile",
         ["xgm_extra_lights_label"] = "Iluminação do dock",
         ["xgm_extra_brightness_label"] = "Brilho",
+        ["xgm_pcie_pm_hint"] = "Se a troca ao vivo travar, adicione pcie_port_pm=off à linha de comando do kernel.",
         ["xgm_fan"] = "Ventoinha XG Mobile",
         ["confirm_yes"] = "Sim",
         ["confirm_no"] = "Não",

--- a/src/I18n/Languages/Romanian.cs
+++ b/src/I18n/Languages/Romanian.cs
@@ -765,6 +765,7 @@ public static class Romanian
         ["xgm_extra_header"] = "Stație de andocare XG Mobile",
         ["xgm_extra_lights_label"] = "Lumini stație",
         ["xgm_extra_brightness_label"] = "Luminozitate",
+        ["xgm_pcie_pm_hint"] = "Dacă comutarea la cald se blochează, adăugați pcie_port_pm=off în linia de comandă a nucleului.",
         ["xgm_fan"] = "Ventilator XG Mobile",
         ["confirm_yes"] = "Da",
         ["confirm_no"] = "Nu",

--- a/src/I18n/Languages/Russian.cs
+++ b/src/I18n/Languages/Russian.cs
@@ -765,6 +765,7 @@ public static class Russian
         ["xgm_extra_header"] = "Док-станция XG Mobile",
         ["xgm_extra_lights_label"] = "Подсветка дока",
         ["xgm_extra_brightness_label"] = "Яркость",
+        ["xgm_pcie_pm_hint"] = "Если переключение на ходу зависает, добавьте pcie_port_pm=off в командную строку ядра.",
         ["xgm_fan"] = "Вентилятор XG Mobile",
         ["confirm_yes"] = "Да",
         ["confirm_no"] = "Нет",

--- a/src/I18n/Languages/Serbian.cs
+++ b/src/I18n/Languages/Serbian.cs
@@ -768,6 +768,7 @@ public static class Serbian
         ["xgm_extra_header"] = "XG Mobile dok",
         ["xgm_extra_lights_label"] = "Osvetljenje doka",
         ["xgm_extra_brightness_label"] = "Osvetljenost",
+        ["xgm_pcie_pm_hint"] = "Ако пребацивање у раду блокира, додајте pcie_port_pm=off у командну линију кернела.",
         ["xgm_fan"] = "Ventilator XG Mobile",
         ["confirm_yes"] = "Da",
         ["confirm_no"] = "Ne",

--- a/src/I18n/Languages/Slovak.cs
+++ b/src/I18n/Languages/Slovak.cs
@@ -890,6 +890,7 @@ public static class Slovak
         ["xgm_extra_header"] = "Dok XG Mobile",
         ["xgm_extra_lights_label"] = "Svetlá doku",
         ["xgm_extra_brightness_label"] = "Jas",
+        ["xgm_pcie_pm_hint"] = "Ak sa prepínanie za chodu zasekne, pridajte pcie_port_pm=off do príkazového riadku jadra.",
         ["xgm_fan"] = "Ventilátor XG Mobile",
 
         // Reusable confirm-dialog buttons (used by ConfirmDialog and any

--- a/src/I18n/Languages/Slovenian.cs
+++ b/src/I18n/Languages/Slovenian.cs
@@ -890,6 +890,7 @@ public static class Slovenian
         ["xgm_extra_header"] = "Priklopna postaja XG Mobile",
         ["xgm_extra_lights_label"] = "Luči postaje",
         ["xgm_extra_brightness_label"] = "Svetlost",
+        ["xgm_pcie_pm_hint"] = "Če preklop med delovanjem obstane, dodajte pcie_port_pm=off v ukazno vrstico jedra.",
         ["xgm_fan"] = "Ventilator XG Mobile",
 
         // Reusable confirm-dialog buttons (used by ConfirmDialog and any

--- a/src/I18n/Languages/Spanish.cs
+++ b/src/I18n/Languages/Spanish.cs
@@ -765,6 +765,7 @@ public static class Spanish
         ["xgm_extra_header"] = "Base XG Mobile",
         ["xgm_extra_lights_label"] = "Luces de la base",
         ["xgm_extra_brightness_label"] = "Brillo",
+        ["xgm_pcie_pm_hint"] = "Si el cambio en caliente se bloquea, añade pcie_port_pm=off a la línea de comandos del kernel.",
         ["xgm_fan"] = "Ventilador XG Mobile",
         ["confirm_yes"] = "Sí",
         ["confirm_no"] = "No",

--- a/src/I18n/Languages/Swedish.cs
+++ b/src/I18n/Languages/Swedish.cs
@@ -768,6 +768,7 @@ public static class Swedish
         ["xgm_extra_header"] = "XG Mobile-docka",
         ["xgm_extra_lights_label"] = "Dockbelysning",
         ["xgm_extra_brightness_label"] = "Ljusstyrka",
+        ["xgm_pcie_pm_hint"] = "Om byte under drift hänger, lägg till pcie_port_pm=off på kernelns kommandorad.",
         ["xgm_fan"] = "XG Mobile-fläkt",
         ["confirm_yes"] = "Ja",
         ["confirm_no"] = "Nej",

--- a/src/I18n/Languages/Thai.cs
+++ b/src/I18n/Languages/Thai.cs
@@ -768,6 +768,7 @@ public static class Thai
         ["xgm_extra_header"] = "ด็อก XG Mobile",
         ["xgm_extra_lights_label"] = "ไฟด็อก",
         ["xgm_extra_brightness_label"] = "ความสว่าง",
+        ["xgm_pcie_pm_hint"] = "หากการสลับแบบสดค้าง ให้เพิ่ม pcie_port_pm=off ในบรรทัดคำสั่งเคอร์เนล",
         ["xgm_fan"] = "พัดลม XG Mobile",
         ["confirm_yes"] = "ใช่",
         ["confirm_no"] = "ไม่",

--- a/src/I18n/Languages/Turkish.cs
+++ b/src/I18n/Languages/Turkish.cs
@@ -765,6 +765,7 @@ public static class Turkish
         ["xgm_extra_header"] = "XG Mobile Dok",
         ["xgm_extra_lights_label"] = "Dok ışıkları",
         ["xgm_extra_brightness_label"] = "Parlaklık",
+        ["xgm_pcie_pm_hint"] = "Canlı geçiş takılırsa çekirdek komut satırına pcie_port_pm=off ekleyin.",
         ["xgm_fan"] = "XG Mobile fanı",
         ["confirm_yes"] = "Evet",
         ["confirm_no"] = "Hayır",

--- a/src/I18n/Languages/Ukrainian.cs
+++ b/src/I18n/Languages/Ukrainian.cs
@@ -765,6 +765,7 @@ public static class Ukrainian
         ["xgm_extra_header"] = "Док-станція XG Mobile",
         ["xgm_extra_lights_label"] = "Підсвічування доку",
         ["xgm_extra_brightness_label"] = "Яскравість",
+        ["xgm_pcie_pm_hint"] = "Якщо перемикання на ходу зависає, додайте pcie_port_pm=off до командного рядка ядра.",
         ["xgm_fan"] = "Вентилятор XG Mobile",
         ["confirm_yes"] = "Так",
         ["confirm_no"] = "Ні",

--- a/src/I18n/Languages/Vietnamese.cs
+++ b/src/I18n/Languages/Vietnamese.cs
@@ -765,6 +765,7 @@ public static class Vietnamese
         ["xgm_extra_header"] = "Dock XG Mobile",
         ["xgm_extra_lights_label"] = "Đèn dock",
         ["xgm_extra_brightness_label"] = "Độ sáng",
+        ["xgm_pcie_pm_hint"] = "Nếu chuyển đổi trực tiếp bị treo, hãy thêm pcie_port_pm=off vào dòng lệnh kernel.",
         ["xgm_fan"] = "Quạt XG Mobile",
         ["confirm_yes"] = "Có",
         ["confirm_no"] = "Không",

--- a/src/Input/InputDispatcher.cs
+++ b/src/Input/InputDispatcher.cs
@@ -347,18 +347,22 @@ public static class InputDispatcher
         var token = _perfDebounce.Token;
         _ = Task.Delay(300, token).ContinueWith(t =>
         {
-            if (t.IsCanceled) return;
+            if (t.IsCanceled)
+                return;
             int n = Interlocked.Exchange(ref _perfCycleCount, 0);
             Avalonia.Threading.Dispatcher.UIThread.Post(() =>
             {
                 var mode = App.Mode;
-                if (mode == null) return;
+                if (mode == null)
+                    return;
                 // Advance n steps through the mode list
                 int target = Mode.Modes.GetCurrent();
                 var list = Mode.Modes.GetList();
-                if (list.Count == 0) return;
+                if (list.Count == 0)
+                    return;
                 int idx = list.IndexOf(target);
-                if (idx < 0) idx = 0;
+                if (idx < 0)
+                    idx = 0;
                 idx = (idx + n) % list.Count;
                 mode.SetPerformanceMode(list[idx], notify: true);
                 App.UpdateTrayIcon();

--- a/src/UI/Views/DevPanelsWindow.axaml.cs
+++ b/src/UI/Views/DevPanelsWindow.axaml.cs
@@ -24,7 +24,7 @@ public partial class DevPanelsWindow : Window
             () => App.MainWindowInstance?.RefreshScreenPublic()),
         new("Aura keyboard panel", "Main window", "show_aura_dev",
             () => App.MainWindowInstance?.RefreshKeyboard()),
-        new("XG Mobile button", "Main window", "show_xgm_dev",
+        new("XG Mobile button + dock panel", "Main window / Extra Settings (reopen)", "show_xgm_dev",
             () => App.MainWindowInstance?.RefreshAllyPanel()),
         new("Suspend mode combo", "Extra Settings (reopen)", "show_deep_sleep_dev", null),
         new("EPP combos", "Extra Settings (reopen)", "show_epp_dev", null),

--- a/src/UI/Views/ExtraWindow.axaml
+++ b/src/UI/Views/ExtraWindow.axaml
@@ -702,6 +702,11 @@
                                    HorizontalAlignment="Center"
                                    VerticalAlignment="Center" />
                     </Grid>
+                    <!-- Boot parameter hint. Selectable so it can be copied. -->
+                    <SelectableTextBlock x:Name="labelXgmPciePmHint"
+                                         Classes="label-dim" FontSize="10"
+                                         TextWrapping="Wrap" TextTrimming="None"
+                                         Text="" Margin="0,8,0,0" />
                 </StackPanel>
             </Border>
 

--- a/src/UI/Views/ExtraWindow.axaml.cs
+++ b/src/UI/Views/ExtraWindow.axaml.cs
@@ -224,6 +224,7 @@ public partial class ExtraWindow : Window
         labelXgmHeader.Text = Labels.Get("xgm_extra_header");
         checkXGMLights.Content = Labels.Get("xgm_extra_lights_label");
         labelXgmBrightnessLabel.Text = Labels.Get("xgm_extra_brightness_label");
+        labelXgmPciePmHint.Text = Labels.Get("xgm_pcie_pm_hint");
         InitXgmPanel();
         checkNvidiaPowerdBattery.Content = Labels.Get("nvidia_powerd_battery");
         InitNvidiaPowerdBattery();

--- a/src/UI/Views/ExtraWindow.axaml.cs
+++ b/src/UI/Views/ExtraWindow.axaml.cs
@@ -2594,7 +2594,7 @@ public partial class ExtraWindow : Window
     private void InitXgmPanel()
     {
         bool present = USB.XGM.IsLightAvailable();
-        panelXGM.IsVisible = present;
+        panelXGM.IsVisible = present || Helpers.AppConfig.Is("show_xgm_dev");
         if (!present)
             return;
 

--- a/vendor/gpu-helper/nvidia_ops.c
+++ b/vendor/gpu-helper/nvidia_ops.c
@@ -376,7 +376,8 @@ int do_nvidia_refcnt_holders(void)
                 if (fgets(comm, sizeof(comm), cf))
                 {
                     char *nl = strchr(comm, '\n');
-                    if (nl) *nl = '\0';
+                    if (nl)
+                        *nl = '\0';
                 }
                 fclose(cf);
             }
@@ -423,7 +424,8 @@ int do_nvidia_refcnt_holders(void)
                         while (p > cgline && *(p - 1) != '/')
                             p--;
                         size_t len = (size_t)(svc + 8 - p);
-                        if (len >= sizeof(unit)) len = sizeof(unit) - 1;
+                        if (len >= sizeof(unit))
+                            len = sizeof(unit) - 1;
                         memcpy(unit, p, len);
                         unit[len] = '\0';
                         break;


### PR DESCRIPTION
## v1.0.91 (2026-08-19)

### Added

- XG Mobile: dock panel hints to add `pcie_port_pm=off` when live switching hangs (#171).

### Fixed

- udev rules return success when a node is absent, so systemd-udevd stops logging false RUN failures (#165, thanks @tlamoureux24).

### Changed

- Svg.Controls.Skia.Avalonia 12.0.0.15, ILCompiler 10.0.10.